### PR TITLE
add wine 8 image

### DIFF
--- a/.github/workflows/wine.yml
+++ b/.github/workflows/wine.yml
@@ -19,6 +19,7 @@ jobs:
           - latest
           - devel
           - staging
+          - '8'
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3

--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ is tagged correctly.
 ### [Wine](/wine)
 
 * [`Wine`](/wine)
+  * `ghcr.io/parkervcp/yolks:wine_8`
   * `ghcr.io/parkervcp/yolks:wine_latest`
   * `ghcr.io/parkervcp/yolks:wine_devel`
   * `ghcr.io/parkervcp/yolks:wine_staging`

--- a/wine/8/Dockerfile
+++ b/wine/8/Dockerfile
@@ -1,0 +1,35 @@
+## use latest build at base that still has wine 8 (8.0.2)
+FROM            ghcr.io/parkervcp/yolks:wine_latest@sha256:db82ec2e67fe90d7d66500c3de64a079051a34ad7d2a5ed480c8c72117f9af04
+
+## install required packages but hold all wine packages
+RUN             dpkg --add-architecture i386 \
+                && apt-mark hold winehq-stable \
+                && apt-mark hold wine-stable-amd64 \
+                && apt-mark hold wine-stable \
+                && apt update -y \
+				&& apt upgrade -y \
+                && rm /usr/sbin/winetricks /entrypoint.sh
+
+## Install rcon in it as this was added later then the base image release
+RUN             cd /tmp/ \
+                && curl -sSL https://github.com/gorcon/rcon-cli/releases/download/v0.10.3/rcon-0.10.3-amd64_linux.tar.gz > rcon.tar.gz \
+                && tar xvf rcon.tar.gz \
+                && mv rcon-0.10.3-amd64_linux/rcon /usr/local/bin/
+
+
+# Update the Winetricks version
+RUN	            wget -q -O /usr/sbin/winetricks https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks \
+                && chmod +x /usr/sbin/winetricks
+
+ENV             HOME=/home/container
+ENV             WINEPREFIX=/home/container/.wine
+ENV             WINEDLLOVERRIDES="mscoree,mshtml="
+ENV             DISPLAY=:0
+ENV             DISPLAY_WIDTH=1024
+ENV             DISPLAY_HEIGHT=768
+ENV             DISPLAY_DEPTH=16
+ENV             AUTO_UPDATE=1
+ENV             XVFB=1
+
+COPY            ./../entrypoint.sh /entrypoint.sh
+CMD             [ "/bin/bash", "/entrypoint.sh" ]


### PR DESCRIPTION
## Description

- add a wine 8 image as the new wine 9 broke some games and (again) depending on the game may have no console output
- This is based of the latest build of itself that still has wine 8 as installing a specific version of wine is a not that easy
- all wine packages are on hold to keep them at 8
- there is an apt update and upgrade for the packages
- there is a setup for the newer version of Winetricks
- RCON cli is downloaded as that PR then was not made / merged yet

Yes this image was test build and indeed is still on 8.0.2
![afbeelding](https://github.com/parkervcp/yolks/assets/67589015/046f0544-f1c1-4a2d-b307-8073a1c630b3)

(please squash merge, as in the commit message I made a typo `/` instead of`8`)
### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?

<!-- The new image submission below can be removed if you are not adding a new image -->

### New Image Submissions:

1. [x] Have you added your image to the [Github workflows](https://github.com/parkervcp/yolks/tree/master/.github/workflows)?
2. [x] Have you updated the README list to contain your new image?
