### PR TITLE
Add RCon Client for DayZ image

### DIFF
--- a/games/dayz/Dockerfile
+++ b/games/dayz/Dockerfile
@@ -28,6 +28,11 @@ RUN         dpkg --add-architecture i386 \
                 libnss-wrapper \
                 tini
 
+## install rcon client (bercon)
+RUN         cd /tmp/ \
+            && curl -sSL https://github.com/WoozyMasta/bercon/releases/download/1.0.0/bercon > bercon \
+            && mv bercon /usr/local/bin/
+
 ## Configure locale
 RUN         update-locale lang=en_US.UTF-8 \
             && dpkg-reconfigure --frontend noninteractive locales


### PR DESCRIPTION
## Description

Added rcon client installation for DayZ image. This will provide a rcon client for Battleye protocol which is used by DayZ and Arma series.

### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?
