### PR TITLE
Change `echo "${STARTUP}"` to `echo -e ${STARTUP}`

### DIFF
--- a/cassandra/entrypoint.sh
+++ b/cassandra/entrypoint.sh
@@ -29,7 +29,7 @@ fi
 # Convert all of the "{{VARIABLE}}" parts of the command into the expected shell
 # variable format of "${VARIABLE}" before evaluating the string and automatically
 # replacing the values.
-PARSED=$(echo "${STARTUP}" | sed -e 's/{{/${/g' -e 's/}}/}/g' | eval echo "$(cat -)")
+PARSED=$(echo -e ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g' | eval echo "$(cat -)")
 
 # Display the command we're running in the output, and then execute it with the env
 # from the container itself.

--- a/erlang/entrypoint.sh
+++ b/erlang/entrypoint.sh
@@ -16,7 +16,7 @@ erl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'i
 # Convert all of the "{{VARIABLE}}" parts of the command into the expected shell
 # variable format of "${VARIABLE}" before evaluating the string and automatically
 # replacing the values.
-PARSED=$(echo "${STARTUP}" | sed -e 's/{{/${/g' -e 's/}}/}/g' | eval echo "$(cat -)")
+PARSED=$(echo -e ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g' | eval echo "$(cat -)")
 
 # Display the command we're running in the output, and then execute it with the env
 # from the container itself.

--- a/go/entrypoint.sh
+++ b/go/entrypoint.sh
@@ -40,7 +40,7 @@ go version
 # Convert all of the "{{VARIABLE}}" parts of the command into the expected shell
 # variable format of "${VARIABLE}" before evaluating the string and automatically
 # replacing the values.
-PARSED=$(echo "${STARTUP}" | sed -e 's/{{/${/g' -e 's/}}/}/g' | eval echo "$(cat -)")
+PARSED=$(echo -e ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g' | eval echo "$(cat -)")
 
 # Display the command we're running in the output, and then execute it with the env
 # from the container itself.

--- a/java/entrypoint.sh
+++ b/java/entrypoint.sh
@@ -40,7 +40,7 @@ java -version
 # Convert all of the "{{VARIABLE}}" parts of the command into the expected shell
 # variable format of "${VARIABLE}" before evaluating the string and automatically
 # replacing the values.
-PARSED=$(echo "${STARTUP}" | sed -e 's/{{/${/g' -e 's/}}/}/g' | eval echo "$(cat -)")
+PARSED=$(echo -e ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g' | eval echo "$(cat -)")
 
 # Display the command we're running in the output, and then execute it with the env
 # from the container itself.

--- a/oses/alpine/entrypoint.sh
+++ b/oses/alpine/entrypoint.sh
@@ -34,7 +34,7 @@ cd /home/container || exit 1
 # Convert all of the "{{VARIABLE}}" parts of the command into the expected shell
 # variable format of "${VARIABLE}" before evaluating the string and automatically
 # replacing the values.
-PARSED=$(echo "${STARTUP}" | sed -e 's/{{/${/g' -e 's/}}/}/g' | eval echo "$(cat -)")
+PARSED=$(echo -e ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g' | eval echo "$(cat -)")
 
 # Display the command we're running in the output, and then execute it with the env
 # from the container itself.

--- a/voice/teaspeak/entrypoint.sh
+++ b/voice/teaspeak/entrypoint.sh
@@ -15,7 +15,7 @@ echo "installed youtube-dl Version:"
 # Convert all of the "{{VARIABLE}}" parts of the command into the expected shell
 # variable format of "${VARIABLE}" before evaluating the string and automatically
 # replacing the values.
-PARSED=$(echo "${STARTUP}" | sed -e 's/{{/${/g' -e 's/}}/}/g' | eval echo "$(cat -)")
+PARSED=$(echo -e ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g' | eval echo "$(cat -)")
 
 # Display the command we're running in the output, and then execute it with the env
 # from the container itself.


### PR DESCRIPTION
## Description

All other `entrypoint.sh` files use this change, so just making the incorrect ones match the rest
It also caused issues with complex startup commands that utilize if statements and such, so hopefully this fixes those issues

Example of startup command that didn't work:
```sh
if [[ "a" == "a" ]]; then
  java -version;
fi;
```
Would error out with this message: `syntax error near unexpected token 'then'`

<!-- Please explain what is being changed or added as a short overview for this PR. Also, link existing relevant issues if they exist with resolves # -->

### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?

<!-- The new image submission below can be removed if you are not adding a new image -->
