### PR TITLE
Remove `eval echo "$(cat -)"`

### DIFF
--- a/cassandra/entrypoint.sh
+++ b/cassandra/entrypoint.sh
@@ -29,7 +29,7 @@ fi
 # Convert all of the "{{VARIABLE}}" parts of the command into the expected shell
 # variable format of "${VARIABLE}" before evaluating the string and automatically
 # replacing the values.
-PARSED=$(echo -e ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g' | eval echo "$(cat -)")
+PARSED=$(echo -e ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')
 
 # Display the command we're running in the output, and then execute it with the env
 # from the container itself.

--- a/erlang/entrypoint.sh
+++ b/erlang/entrypoint.sh
@@ -16,7 +16,7 @@ erl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'i
 # Convert all of the "{{VARIABLE}}" parts of the command into the expected shell
 # variable format of "${VARIABLE}" before evaluating the string and automatically
 # replacing the values.
-PARSED=$(echo -e ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g' | eval echo "$(cat -)")
+PARSED=$(echo -e ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')
 
 # Display the command we're running in the output, and then execute it with the env
 # from the container itself.

--- a/go/entrypoint.sh
+++ b/go/entrypoint.sh
@@ -40,7 +40,7 @@ go version
 # Convert all of the "{{VARIABLE}}" parts of the command into the expected shell
 # variable format of "${VARIABLE}" before evaluating the string and automatically
 # replacing the values.
-PARSED=$(echo -e ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g' | eval echo "$(cat -)")
+PARSED=$(echo -e ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')
 
 # Display the command we're running in the output, and then execute it with the env
 # from the container itself.

--- a/java/entrypoint.sh
+++ b/java/entrypoint.sh
@@ -40,7 +40,7 @@ java -version
 # Convert all of the "{{VARIABLE}}" parts of the command into the expected shell
 # variable format of "${VARIABLE}" before evaluating the string and automatically
 # replacing the values.
-PARSED=$(echo -e ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g' | eval echo "$(cat -)")
+PARSED=$(echo -e ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')
 
 # Display the command we're running in the output, and then execute it with the env
 # from the container itself.

--- a/oses/alpine/entrypoint.sh
+++ b/oses/alpine/entrypoint.sh
@@ -34,7 +34,7 @@ cd /home/container || exit 1
 # Convert all of the "{{VARIABLE}}" parts of the command into the expected shell
 # variable format of "${VARIABLE}" before evaluating the string and automatically
 # replacing the values.
-PARSED=$(echo -e ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g' | eval echo "$(cat -)")
+PARSED=$(echo -e ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')
 
 # Display the command we're running in the output, and then execute it with the env
 # from the container itself.

--- a/voice/teaspeak/entrypoint.sh
+++ b/voice/teaspeak/entrypoint.sh
@@ -15,7 +15,7 @@ echo "installed youtube-dl Version:"
 # Convert all of the "{{VARIABLE}}" parts of the command into the expected shell
 # variable format of "${VARIABLE}" before evaluating the string and automatically
 # replacing the values.
-PARSED=$(echo -e ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g' | eval echo "$(cat -)")
+PARSED=$(echo -e ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')
 
 # Display the command we're running in the output, and then execute it with the env
 # from the container itself.


### PR DESCRIPTION
## Description

Pull request #259 was supposed to fix complex startup commands that used if statements, but it didn't work. I tested this new fix on a local/private docker image and it works!
Doesn't seem like `eval echo "$(cat -)"` was needed as everything still works as expected. Not exactly sure what it does to be honest as it just seems to echo the startup command after parsing, but was causing errors with if-then statements.

### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?