### PR TITLE
Fix #261

### DIFF
--- a/cassandra/entrypoint.sh
+++ b/cassandra/entrypoint.sh
@@ -29,10 +29,10 @@ fi
 # Convert all of the "{{VARIABLE}}" parts of the command into the expected shell
 # variable format of "${VARIABLE}" before evaluating the string and automatically
 # replacing the values.
-PARSED=$(echo -e ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')
+PARSED=$(echo "$STARTUP" | sed -e 's/{{/${/g' -e 's/}}/}/g')
 
-# Display the command we're running in the output, and then execute it with the env
-# from the container itself.
-printf "\033[1m\033[33mcontainer@pelican~ \033[0m%s\n" "$PARSED"
+# Display the command we're running in the output, and then execute it with eval
+printf "\033[1m\033[33mcontainer@pelican~ \033[0m"
+echo "$PARSED"
 # shellcheck disable=SC2086
-exec env ${PARSED}
+eval "$PARSED"

--- a/erlang/entrypoint.sh
+++ b/erlang/entrypoint.sh
@@ -16,10 +16,10 @@ erl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'i
 # Convert all of the "{{VARIABLE}}" parts of the command into the expected shell
 # variable format of "${VARIABLE}" before evaluating the string and automatically
 # replacing the values.
-PARSED=$(echo -e ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')
+PARSED=$(echo "$STARTUP" | sed -e 's/{{/${/g' -e 's/}}/}/g')
 
-# Display the command we're running in the output, and then execute it with the env
-# from the container itself.
-printf "\033[1m\033[33mcontainer@pelican~ \033[0m%s\n" "$PARSED"
+# Display the command we're running in the output, and then execute it with eval
+printf "\033[1m\033[33mcontainer@pelican~ \033[0m"
+echo "$PARSED"
 # shellcheck disable=SC2086
-exec env ${PARSED}
+eval "$PARSED"

--- a/go/entrypoint.sh
+++ b/go/entrypoint.sh
@@ -40,10 +40,10 @@ go version
 # Convert all of the "{{VARIABLE}}" parts of the command into the expected shell
 # variable format of "${VARIABLE}" before evaluating the string and automatically
 # replacing the values.
-PARSED=$(echo -e ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')
+PARSED=$(echo "$STARTUP" | sed -e 's/{{/${/g' -e 's/}}/}/g')
 
-# Display the command we're running in the output, and then execute it with the env
-# from the container itself.
-printf "\033[1m\033[33mcontainer@pelican~ \033[0m%s\n" "$PARSED"
+# Display the command we're running in the output, and then execute it with eval
+printf "\033[1m\033[33mcontainer@pelican~ \033[0m"
+echo "$PARSED"
 # shellcheck disable=SC2086
-exec env ${PARSED}
+eval "$PARSED"

--- a/java/entrypoint.sh
+++ b/java/entrypoint.sh
@@ -40,10 +40,10 @@ java -version
 # Convert all of the "{{VARIABLE}}" parts of the command into the expected shell
 # variable format of "${VARIABLE}" before evaluating the string and automatically
 # replacing the values.
-PARSED=$(echo -e ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')
+PARSED=$(echo "$STARTUP" | sed -e 's/{{/${/g' -e 's/}}/}/g')
 
-# Display the command we're running in the output, and then execute it with the env
-# from the container itself.
-printf "\033[1m\033[33mcontainer@pelican~ \033[0m%s\n" "$PARSED"
+# Display the command we're running in the output, and then execute it with eval
+printf "\033[1m\033[33mcontainer@pelican~ \033[0m"
+echo "$PARSED"
 # shellcheck disable=SC2086
-eval ${PARSED}
+eval "$PARSED"

--- a/oses/alpine/entrypoint.sh
+++ b/oses/alpine/entrypoint.sh
@@ -34,11 +34,11 @@ cd /home/container || exit 1
 # Convert all of the "{{VARIABLE}}" parts of the command into the expected shell
 # variable format of "${VARIABLE}" before evaluating the string and automatically
 # replacing the values.
-PARSED=$(echo -e ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')
+PARSED=$(echo "$STARTUP" | sed -e 's/{{/${/g' -e 's/}}/}/g')
 
-# Display the command we're running in the output, and then execute it with the env
-# from the container itself.
-printf "\033[1m\033[33mcontainer@pelican~ \033[0m%s\n" "$PARSED"
+# Display the command we're running in the output, and then execute it with eval
+printf "\033[1m\033[33mcontainer@pelican~ \033[0m"
+echo "$PARSED"
 # shellcheck disable=SC2086
-exec env ${PARSED}
+eval "$PARSED"
 

--- a/voice/teaspeak/entrypoint.sh
+++ b/voice/teaspeak/entrypoint.sh
@@ -15,10 +15,10 @@ echo "installed youtube-dl Version:"
 # Convert all of the "{{VARIABLE}}" parts of the command into the expected shell
 # variable format of "${VARIABLE}" before evaluating the string and automatically
 # replacing the values.
-PARSED=$(echo -e ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')
+PARSED=$(echo "$STARTUP" | sed -e 's/{{/${/g' -e 's/}}/}/g')
 
-# Display the command we're running in the output, and then execute it with the env
-# from the container itself.
-printf "\033[1m\033[33mcontainer@pelican~ \033[0m%s\n" "$PARSED"
+# Display the command we're running in the output, and then execute it with eval
+printf "\033[1m\033[33mcontainer@pelican~ \033[0m"
+echo "$PARSED"
 # shellcheck disable=SC2086
-exec env ${PARSED}
+eval "$PARSED"


### PR DESCRIPTION
## Description

- Print the startup command using `echo` instead of `printf`
  - Since `printf` doesn't add a newline automatically, the startup command is still displayed on the same line as `container@pelican~`, visually accomplishing the same thing as before
- `echo -e ${STARTUP}` was changed to `echo "$STARTUP"` to avoid colors being converted during parsing
  - Realized this is basically just reverting my previous PR, #259... (but that PR didn't accomplish its goal and was superseded by #260)
  - `-e` shouldn't actually be necessary, as the parsing is just to replace `{{VARIABLE}}` with `${VARIABLE}`, so backslash escape interpretation is not needed
- Updated other relevant images to match the changes that the Java image has been receiving

### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?