### PR TITLE
added custom core keeper docker image which uses nss wrapper

### DIFF
--- a/.github/workflows/games.yml
+++ b/.github/workflows/games.yml
@@ -25,6 +25,7 @@ jobs:
           - source
           - valheim
           - thebattleforwesnoth
+          - corekeeper
           
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ is tagged correctly.
   * `ghcr.io/parkervcp/games:thebattleforwesnoth`
 * [`valheim`](/games/valheim)
   * `ghcr.io/parkervcp/games:valheim`
+* [`corekeeper`](/games/corekeeper)
+  * `ghcr.io/parkervcp/games:corekeeper`
+
 
 ### [Golang](/go)
 

--- a/games/corekeeper/Dockerfile
+++ b/games/corekeeper/Dockerfile
@@ -1,0 +1,46 @@
+FROM        --platform=$TARGETOS/$TARGETARCH debian:bookworm-slim
+
+LABEL       author="Omar Sanchez" maintainer="omarsanchezdev@gmail.com"
+
+ENV         DEBIAN_FRONTEND=noninteractive
+
+RUN         dpkg --add-architecture i386 \
+            && apt-get update \
+            && apt-get upgrade -y \
+            && apt-get install -y tar curl gcc g++ lib32gcc-s1 libgcc-12-dev libgcc-11-dev libcurl4-gnutls-dev:i386 libssl-dev:i386 libcurl4:i386 lib32tinfo6 libtinfo6:i386 lib32z1 lib32stdc++6 libncurses5:i386 libcurl3-gnutls:i386 libsdl2-2.0-0:i386 libsdl2-2.0-0 iproute2 gdb libsdl1.2debian libfontconfig1 telnet net-tools netcat-traditional tzdata numactl xvfb libxi6 wget tini libpulse-dev gettext locales libnss-wrapper \
+            && useradd -m -d /home/container container
+
+## configure locale
+RUN   update-locale lang=en_US.UTF-8 \
+        &&   dpkg-reconfigure --frontend noninteractive locales
+
+## install rcon
+RUN         cd /tmp/ \
+            && curl -sSL https://github.com/gorcon/rcon-cli/releases/download/v0.10.3/rcon-0.10.3-amd64_linux.tar.gz > rcon.tar.gz \
+            && tar xvf rcon.tar.gz \
+            && mv rcon-0.10.3-amd64_linux/rcon /usr/local/bin/
+
+            # Temp fix for things that still need libssl1.1
+RUN         if [ "$(uname -m)" = "x86_64" ]; then \
+                wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4_amd64.deb && \
+                dpkg -i libssl1.1_1.1.0g-2ubuntu4_amd64.deb && \
+                rm libssl1.1_1.1.0g-2ubuntu4_amd64.deb; \
+            fi
+
+ENV         USER=container HOME=/home/container
+WORKDIR     /home/container
+
+## Prepare NSS Wrapper for the entrypoint as a workaround for Core Keeper plugin libparty.so requiring a valid /etc/password
+ENV         NSS_WRAPPER_PASSWD=/tmp/passwd NSS_WRAPPER_GROUP=/tmp/group
+RUN         touch ${NSS_WRAPPER_PASSWD} ${NSS_WRAPPER_GROUP} \
+            && chgrp 0 ${NSS_WRAPPER_PASSWD} ${NSS_WRAPPER_GROUP} \
+            && chmod g+rw ${NSS_WRAPPER_PASSWD} ${NSS_WRAPPER_GROUP}
+ADD         passwd.template /passwd.template
+
+STOPSIGNAL SIGINT
+
+COPY        --chown=container:container entrypoint.sh /entrypoint.sh
+RUN         chmod +x /entrypoint.sh
+
+ENTRYPOINT    ["/usr/bin/tini", "-g", "--"]
+CMD         ["/entrypoint.sh"]

--- a/games/corekeeper/entrypoint.sh
+++ b/games/corekeeper/entrypoint.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+#
+# Copyright (c) 2021 Matthew Penner
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+# Wait for the container to fully initialize
+sleep 1
+
+# Default the TZ environment variable to UTC.
+TZ=${TZ:-UTC}
+export TZ
+
+# Set environment variable that holds the Internal Docker IP
+INTERNAL_IP=$(ip route get 1 | awk '{print $(NF-2);exit}')
+export INTERNAL_IP
+
+# Set environment for Steam Proton
+if [ -f "/usr/local/bin/proton" ]; then
+    if [ ! -z ${SRCDS_APPID} ]; then
+	    mkdir -p /home/container/.steam/steam/steamapps/compatdata/${SRCDS_APPID}
+        export STEAM_COMPAT_CLIENT_INSTALL_PATH="/home/container/.steam/steam"
+        export STEAM_COMPAT_DATA_PATH="/home/container/.steam/steam/steamapps/compatdata/${SRCDS_APPID}"
+        # Fix for pipx with protontricks
+        export PATH=$PATH:/root/.local/bin
+    else
+        echo -e "----------------------------------------------------------------------------------"
+        echo -e "WARNING!!! Proton needs variable SRCDS_APPID, else it will not work. Please add it"
+        echo -e "Server stops now"
+        echo -e "----------------------------------------------------------------------------------"
+        exit 0
+        fi
+fi
+
+# Switch to the container's working directory
+cd /home/container || exit 1
+
+## just in case someone removed the defaults.
+if [ "${STEAM_USER}" == "" ]; then
+    echo -e "steam user is not set.\n"
+    echo -e "Using anonymous user.\n"
+    STEAM_USER=anonymous
+    STEAM_PASS=""
+    STEAM_AUTH=""
+else
+    echo -e "user set to ${STEAM_USER}"
+fi
+
+## if auto_update is not set or to 1 update
+if [ -z ${AUTO_UPDATE} ] || [ "${AUTO_UPDATE}" == "1" ]; then 
+    # Update Source Server
+    if [ ! -z ${SRCDS_APPID} ]; then
+	    if [ "${STEAM_USER}" == "anonymous" ]; then
+            ./steamcmd/steamcmd.sh +force_install_dir /home/container +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} $( [[ "${WINDOWS_INSTALL}" == "1" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update ${SRCDS_APPID} +app_update 1007 $( [[ -z ${SRCDS_BETAID} ]] || printf %s "-beta ${SRCDS_BETAID}" ) $( [[ -z ${SRCDS_BETAPASS} ]] || printf %s "-betapassword ${SRCDS_BETAPASS}" ) $( [[ -z ${HLDS_GAME} ]] || printf %s "+app_set_config 90 mod ${HLDS_GAME}" )  ${INSTALL_FLAGS} $( [[ "${VALIDATE}" == "1" ]] && printf %s 'validate' ) +quit
+	    else
+            numactl --physcpubind=+0 ./steamcmd/steamcmd.sh +force_install_dir /home/container +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} $( [[ "${WINDOWS_INSTALL}" == "1" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update ${SRCDS_APPID} +app_update 1007 $( [[ -z ${SRCDS_BETAID} ]] || printf %s "-beta ${SRCDS_BETAID}" ) $( [[ -z ${SRCDS_BETAPASS} ]] || printf %s "-betapassword ${SRCDS_BETAPASS}" ) $( [[ -z ${HLDS_GAME} ]] || printf %s "+app_set_config 90 mod ${HLDS_GAME}" ) ${INSTALL_FLAGS} $( [[ "${VALIDATE}" == "1" ]] && printf %s 'validate' ) +quit
+	    fi
+    else
+        echo -e "No appid set. Starting Server"
+    fi
+
+else
+    echo -e "Not updating game server as auto update was set to 0. Starting Server"
+fi
+
+## copy steamcmd client binaries
+## Set up 32 bit libraries
+mkdir -p /home/container/.steam/sdk32
+cp -v /steamcmd/linux32/steamclient.so /home/container/.steam/sdk32/steamclient.so
+
+## Set up 64 bit libraries
+mkdir -p /home/container/.steam/sdk64
+cp -v /steamcmd/linux64/steamclient.so /home/container/.steam/sdk64/steamclient.so
+
+# Setup NSS Wrapper for use ($NSS_WRAPPER_PASSWD and $NSS_WRAPPER_GROUP have been set by the Dockerfile)
+export USER_ID=$(id -u)
+export GROUP_ID=$(id -g)
+envsubst < /passwd.template > ${NSS_WRAPPER_PASSWD}
+
+export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libnss_wrapper.so
+
+# Replace Startup Variables
+MODIFIED_STARTUP=$(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')
+echo -e ":/home/container$ ${MODIFIED_STARTUP}"
+
+# Run the Server
+eval ${MODIFIED_STARTUP}

--- a/games/corekeeper/passwd.template
+++ b/games/corekeeper/passwd.template
@@ -1,0 +1,26 @@
+root:x:0:0:root:/root:/bin/bash
+daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
+bin:x:2:2:bin:/bin:/usr/sbin/nologin
+sys:x:3:3:sys:/dev:/usr/sbin/nologin
+sync:x:4:65534:sync:/bin:/bin/sync
+games:x:5:60:games:/usr/games:/usr/sbin/nologin
+man:x:6:12:man:/var/cache/man:/usr/sbin/nologin
+lp:x:7:7:lp:/var/spool/lpd:/usr/sbin/nologin
+mail:x:8:8:mail:/var/mail:/usr/sbin/nologin
+news:x:9:9:news:/var/spool/news:/usr/sbin/nologin
+uucp:x:10:10:uucp:/var/spool/uucp:/usr/sbin/nologin
+proxy:x:13:13:proxy:/bin:/usr/sbin/nologin
+www-data:x:33:33:www-data:/var/www:/usr/sbin/nologin
+backup:x:34:34:backup:/var/backups:/usr/sbin/nologin
+list:x:38:38:Mailing List Manager:/var/list:/usr/sbin/nologin
+irc:x:39:39:ircd:/var/run/ircd:/usr/sbin/nologin
+gnats:x:41:41:Gnats Bug-Reporting System (admin):/var/lib/gnats:/usr/sbin/nologin
+nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
+systemd-timesync:x:100:102:systemd Time Synchronization,,,:/run/systemd:/bin/false
+systemd-network:x:101:103:systemd Network Management,,,:/run/systemd/netif:/bin/false
+systemd-resolve:x:102:104:systemd Resolver,,,:/run/systemd/resolve:/bin/false
+systemd-bus-proxy:x:103:105:systemd Bus Proxy,,,:/run/systemd:/bin/false
+syslog:x:104:108::/home/syslog:/bin/false
+messagebus:x:106:109::/var/run/dbus:/bin/false
+bind:x:108:112::/var/cache/bind:/bin/false
+${USER_NAME}:x:${USER_ID}:${GROUP_ID}:${USER_NAME}:${HOME}:/bin/bash


### PR DESCRIPTION
## Description

added custom docker image for core keeper game as a requirement to use the libparty.so plugin https://github.com/PlayFab/PlayFabParty. this plugin is used for cross play on core keeper servers. The following plugin on recent release was causing segfault errors. after investigation I found that the cause was a failure on function calls in c lib getuid(); and getpwuid(uid); which relies on access to the /etc/passwd file. due to the nature of the docker containers when using wings, this directory is not available so the command fails. Another game valheim experienced similar issues. Until the latest version of wings is released, which contains fixes for mounting this directory as pointed here https://github.com/pterodactyl/wings/pull/197, this is the workaround.


### All Submissions:

* [X] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [X] Have you created a new branch for your changes and PR from that branch and not from your master branch?

<!-- The new image submission below can be removed if you are not adding a new image -->

### New Image Submissions:

1. [X] Have you added your image to the [Github workflows](https://github.com/parkervcp/yolks/tree/master/.github/workflows)?
yes

2. [X] Have you updated the README list to contain your new image?
yes
