### PR TITLE
[oses/ubuntu] Bump Ubuntu to latest LTS

### DIFF
--- a/oses/ubuntu/Dockerfile
+++ b/oses/ubuntu/Dockerfile
@@ -1,31 +1,35 @@
-FROM  --platform=$TARGETOS/$TARGETARCH ubuntu:22.04
+FROM        --platform=$TARGETOS/$TARGETARCH ubuntu:24.04
 
-LABEL author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
-ENV   DEBIAN_FRONTEND noninteractive
+LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.licenses=MIT
 
-## add container user
-RUN   useradd -m -d /home/container -s /bin/bash container
+ENV         DEBIAN_FRONTEND=noninteractive
 
-## update base packages
-RUN   apt update \
-        &&   apt upgrade -y
+## Add container user
+RUN         useradd -m -d /home/container -s /bin/bash container
+ENV         USER=container HOME=/home/container
 
-## install dependencies
-RUN   apt install -y gcc g++ libgcc1 libc++-dev gdb libc6 git wget curl tar zip unzip binutils xz-utils liblzo2-2 cabextract iproute2 net-tools netcat telnet libatomic1 libsdl1.2debian libsdl2-2.0-0 \
-        libfontconfig icu-devtools libunwind8 sqlite3 libsqlite3-dev libzip4 locales ffmpeg apt-transport-https init-system-helpers \
-        libcurl3-gnutls liblua5.1-0 libluajit-5.1-2 libsqlite3-0 bzip2 zlib1g libevent-dev libmariadb-dev-compat libmariadb-dev libssl-dev \
-		libfluidsynth-dev libmariadb-dev libicu-dev libssl3 libduktape207 libjsoncpp-dev libleveldb1d libncurses5 libncursesw5 tini 
+## Update base packages
+RUN         apt update \
+            && apt upgrade -y
 
-## configure locale
-RUN   update-locale lang=en_US.UTF-8 \
-        &&   dpkg-reconfigure --frontend noninteractive locales
+## Install dependencies
+RUN         apt install -y gcc g++ libgcc1 libc++-dev gdb libc6 git wget curl tar zip unzip binutils xz-utils liblzo2-2 cabextract iproute2 net-tools netcat-openbsd telnet libatomic1 libsdl1.2debian libsdl2-2.0-0 \
+                libfontconfig icu-devtools libunwind8 sqlite3 libsqlite3-dev libzip4 locales ffmpeg apt-transport-https init-system-helpers \
+                libcurl3-gnutls liblua5.1-0 libluajit-5.1-2 libsqlite3-0 bzip2 zlib1g libevent-dev libmariadb-dev-compat libmariadb-dev libssl-dev \
+                libfluidsynth-dev libmariadb-dev libicu-dev libssl3 libduktape207 libjsoncpp-dev libleveldb1d libncurses6 libncursesw6 tini 
 
-WORKDIR /home/container
+## Configure locale
+RUN         update-locale lang=en_US.UTF-8 \
+            && dpkg-reconfigure --frontend noninteractive locales
 
-STOPSIGNAL SIGINT
+WORKDIR     /home/container
+
+STOPSIGNAL  SIGINT
 
 COPY        --chown=container:container ./entrypoint.sh /entrypoint.sh
 RUN         chmod +x /entrypoint.sh
-ENTRYPOINT    ["/usr/bin/tini", "-g", "--"]
+ENTRYPOINT  ["/usr/bin/tini", "-g", "--"]
 CMD         ["/entrypoint.sh"]

--- a/oses/ubuntu/Dockerfile
+++ b/oses/ubuntu/Dockerfile
@@ -2,7 +2,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH ubuntu:24.04
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
-LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
 ENV         DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## Description

- Bumps Ubuntu to latest LTS version 24.04 (Noble Numbat)
- Unified the Dockerfile's style with Debian's Dockerfile (4-space even indenting)
- Added `org.opencontainers` labels (similar to Debian's Dockerfile)
- Fixed depreciated `DEBIAN_FRONTEND` env line by adding `=`
- Bumped `netcat` package to updated `netcat-openbsd`
- Bumped `libncurses5` package to updated `libncurses6`
- Bumped `libncursesw5` package to updated `libncursesw6`

### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?