### PR TITLE
[Arma 3 & DayZ] Fix SteamCMD error checking

### DIFF
--- a/games/arma3/entrypoint.sh
+++ b/games/arma3/entrypoint.sh
@@ -54,7 +54,8 @@ function RunSteamCMD { #[Input: int server=0 mod=1 optional_mod=2; int id]
 
         # Error checking for SteamCMD
         steamcmdExitCode=${PIPESTATUS[0]}
-        loggedErrors=$(grep -i "error\|failed" "${STEAMCMD_LOG}" | grep -iv "setlocal\|SDL\|steamservice\|thread")
+        # Catch errors (ignore setlocale, SDL, steamservice, thread priority, and libcurl warnings)
+        loggedErrors=$(grep -i "error\|failed" "${STEAMCMD_LOG}" | grep -iv "setlocal\|SDL\|steamservice\|thread\|libcurl")
         if [[ -n ${loggedErrors} ]]; then # Catch errors (ignore setlocale, SDL, steamservice, and thread priority warnings)
             # Soft errors
             if [[ -n $(grep -i "Timeout downloading item" "${STEAMCMD_LOG}") ]]; then # Mod download timeout

--- a/games/arma3/entrypoint.sh
+++ b/games/arma3/entrypoint.sh
@@ -56,7 +56,7 @@ function RunSteamCMD { #[Input: int server=0 mod=1 optional_mod=2; int id]
         steamcmdExitCode=${PIPESTATUS[0]}
         # Catch errors (ignore setlocale, SDL, steamservice, thread priority, and libcurl warnings)
         loggedErrors=$(grep -i "error\|failed" "${STEAMCMD_LOG}" | grep -iv "setlocal\|SDL\|steamservice\|thread\|libcurl")
-        if [[ -n ${loggedErrors} ]]; then # Catch errors (ignore setlocale, SDL, steamservice, and thread priority warnings)
+        if [[ -n ${loggedErrors} ]]; then
             # Soft errors
             if [[ -n $(grep -i "Timeout downloading item" "${STEAMCMD_LOG}") ]]; then # Mod download timeout
                 echo -e "\n${YELLOW}[UPDATE]: ${NC}Timeout downloading Steam Workshop mod: \"${CYAN}${modName}${NC}\" (${CYAN}${2}${NC})"

--- a/games/dayz/entrypoint.sh
+++ b/games/dayz/entrypoint.sh
@@ -53,7 +53,8 @@ function RunSteamCMD { #[Input: int server=0 mod=1; int id]
         
         # Error checking for SteamCMD
         steamcmdExitCode=${PIPESTATUS[0]}
-        if [[ -n $(grep -i "error\|failed" "${STEAMCMD_LOG}" | grep -iv "setlocal\|SDL\|thread") ]]; then # Catch errors (ignore setlocale, SDL, and thread priority warnings)
+        # Catch errors (ignore setlocale, SDL, steamservice, thread priority, and libcurl warnings)
+        if [[ -n $(grep -i "error\|failed" "${STEAMCMD_LOG}" | grep -iv "setlocal\|SDL\|steamservice\|thread\|libcurl") ]]; then
             # Soft errors
             if [[ -n $(grep -i "Timeout downloading item" "${STEAMCMD_LOG}") ]]; then # Mod download timeout
                 echo -e "\n${YELLOW}[UPDATE]: ${NC}Timeout downloading Steam Workshop mod: \"${CYAN}${modName}${NC}\" (${CYAN}${2}${NC})"

--- a/games/dayz/entrypoint.sh
+++ b/games/dayz/entrypoint.sh
@@ -54,7 +54,8 @@ function RunSteamCMD { #[Input: int server=0 mod=1; int id]
         # Error checking for SteamCMD
         steamcmdExitCode=${PIPESTATUS[0]}
         # Catch errors (ignore setlocale, SDL, steamservice, thread priority, and libcurl warnings)
-        if [[ -n $(grep -i "error\|failed" "${STEAMCMD_LOG}" | grep -iv "setlocal\|SDL\|steamservice\|thread\|libcurl") ]]; then
+        loggedErrors=$(grep -i "error\|failed" "${STEAMCMD_LOG}" | grep -iv "setlocal\|SDL\|steamservice\|thread\|libcurl")
+        if [[ -n ${loggedErrors} ]]; then
             # Soft errors
             if [[ -n $(grep -i "Timeout downloading item" "${STEAMCMD_LOG}") ]]; then # Mod download timeout
                 echo -e "\n${YELLOW}[UPDATE]: ${NC}Timeout downloading Steam Workshop mod: \"${CYAN}${modName}${NC}\" (${CYAN}${2}${NC})"


### PR DESCRIPTION
## Description

Added `libcurl` as an excluded keyword for error checking. Was causing mod-timeout errors to be misreported as an unknown error.

### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?
