### PR TITLE
Rust: Carbon repo changed

### DIFF
--- a/games/rust/entrypoint.sh
+++ b/games/rust/entrypoint.sh
@@ -17,9 +17,9 @@ MODIFIED_STARTUP=`eval echo $(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g'
 echo ":/home/container$ ${MODIFIED_STARTUP}"
 
 if [[ "${FRAMEWORK}" == "carbon" ]]; then
-    # Carbon: https://github.com/CarbonCommunity/Carbon.Core
+    # Carbon: https://github.com/CarbonCommunity/Carbon
     echo "Updating Carbon..."
-    curl -sSL "https://github.com/CarbonCommunity/Carbon.Core/releases/download/production_build/Carbon.Linux.Release.tar.gz" | tar zx
+    curl -sSL "https://github.com/CarbonCommunity/Carbon/releases/download/production_build/Carbon.Linux.Release.tar.gz" | tar zx
     echo "Done updating Carbon!"
 
     export DOORSTOP_ENABLED=1


### PR DESCRIPTION
## Description

- The repo name of the rust Carbon framework changed, It did not cause issues as we have a -L flag so curl will follow the redirect that GitHub sends but it is better to still update this.

### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?

<!-- The new image submission below can be removed if you are not adding a new image -->
