### PR TITLE
Update docker Legacy key value format and bump docker/build-push-action to v6

### DIFF
--- a/.github/workflows/apps.yml
+++ b/.github/workflows/apps.yml
@@ -32,7 +32,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_TOKEN }}
       
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v6
         with:
           context: ./apps/${{ matrix.app }}
           file: ./apps/${{ matrix.app }}/Dockerfile

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -30,7 +30,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_TOKEN }}
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v6
         with:
           context: ./oses/${{ matrix.oses }}
           file: ./oses/${{ matrix.oses }}/Dockerfile

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -41,7 +41,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_TOKEN }}
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v6
         with:
           context: ./bot/${{ matrix.tag }}
           file: ./bot/${{ matrix.tag }}/Dockerfile
@@ -76,7 +76,7 @@ jobs:
   #         registry: ghcr.io
   #         username: ${{ github.repository_owner }}
   #         password: ${{ secrets.REGISTRY_TOKEN }}
-  #     - uses: docker/build-push-action@v5
+  #     - uses: docker/build-push-action@v6
   #       with:
   #         context: ./bot/${{ matrix.tag }}
   #         file: ./bot/${{ matrix.tag }}/Dockerfile

--- a/.github/workflows/box64.yml
+++ b/.github/workflows/box64.yml
@@ -28,7 +28,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_TOKEN }}
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v6
         with:
           context: ./box64
           file: ./${{ matrix.tag }}/Dockerfile

--- a/.github/workflows/bun.yml
+++ b/.github/workflows/bun.yml
@@ -29,7 +29,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_TOKEN }}
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v6
         with:
           context: ./bun
           file: ./bun/${{ matrix.tag }}/Dockerfile

--- a/.github/workflows/cassandra.yml
+++ b/.github/workflows/cassandra.yml
@@ -28,7 +28,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_TOKEN }}
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v6
         with:
           context: ./cassandra
           file: ./cassandra/${{ matrix.tag }}/Dockerfile

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -33,7 +33,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_TOKEN }}
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v6
         with:
           context: ./dart
           file: ./dart/${{ matrix.tag }}/Dockerfile

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -35,7 +35,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_TOKEN }}
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v6
         with:
           context: ./dotnet
           file: ./dotnet/${{ matrix.tag }}/Dockerfile

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -32,7 +32,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_TOKEN }}
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v6
         with:
           context: ./elixir
           file: ./elixir/${{ matrix.tag }}/Dockerfile

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -31,7 +31,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_TOKEN }}
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v6
         with:
           context: ./erlang
           file: ./erlang/${{ matrix.tag }}/Dockerfile

--- a/.github/workflows/games.yml
+++ b/.github/workflows/games.yml
@@ -36,7 +36,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_TOKEN }}
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v6
         with:
           context: ./games/${{ matrix.game }}
           file: ./games/${{ matrix.game }}/Dockerfile
@@ -68,7 +68,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_TOKEN }}
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v6
         with:
           context: ./games/${{ matrix.game }}
           file: ./games/${{ matrix.game }}/Dockerfile

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -36,7 +36,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_TOKEN }}
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v6
         with:
           context: ./go
           file: ./go/${{ matrix.tag }}/Dockerfile

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -30,7 +30,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_TOKEN }}
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v6
         with:
           context: ./installers
           file: ./installers/${{ matrix.tag }}/Dockerfile

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -36,7 +36,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_TOKEN }}
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v6
         with:
           context: ./java
           file: ./java/${{ matrix.tag }}/Dockerfile

--- a/.github/workflows/mariadb.yml
+++ b/.github/workflows/mariadb.yml
@@ -36,7 +36,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_TOKEN }}
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v6
         with:
           context: ./mariadb
           file: ./mariadb/${{ matrix.tag }}/Dockerfile

--- a/.github/workflows/mongodb.yml
+++ b/.github/workflows/mongodb.yml
@@ -32,7 +32,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_TOKEN }}
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v6
         with:
           context: ./mongodb
           file: ./mongodb/${{ matrix.tag }}/Dockerfile

--- a/.github/workflows/mono.yml
+++ b/.github/workflows/mono.yml
@@ -27,7 +27,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_TOKEN }}
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v6
         with:
           context: ./mono
           file: ./mono/${{ matrix.tag }}/Dockerfile

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -38,7 +38,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_TOKEN }}
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v6
         with:
           context: ./nodejs
           file: ./nodejs/${{ matrix.tag }}/Dockerfile

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -35,7 +35,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_TOKEN }}
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v6
         with:
           context: ./postgres
           file: ./postgres/${{ matrix.tag }}/Dockerfile

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -36,7 +36,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_TOKEN }}
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v6
         with:
           context: ./python
           file: ./python/${{ matrix.tag }}/Dockerfile

--- a/.github/workflows/redis.yml
+++ b/.github/workflows/redis.yml
@@ -31,7 +31,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_TOKEN }}
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v6
         with:
           context: ./redis
           file: ./redis/${{ matrix.tag }}/Dockerfile

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,7 +31,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_TOKEN }}
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v6
         with:
           context: ./rust
           file: ./rust/${{ matrix.tag }}/Dockerfile

--- a/.github/workflows/steamcmd.yml
+++ b/.github/workflows/steamcmd.yml
@@ -32,7 +32,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_TOKEN }}
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v6
         with:
           context: ./steamcmd
           file: ./steamcmd/${{ matrix.distro }}/Dockerfile

--- a/.github/workflows/voice.yml
+++ b/.github/workflows/voice.yml
@@ -27,7 +27,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_TOKEN }}
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v6
         with:
           context: ./voice/${{ matrix.tag }}
           file: ./voice/${{ matrix.tag }}/Dockerfile
@@ -59,7 +59,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_TOKEN }}
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v6
         with:
           context: ./voice/${{ matrix.tag }}
           file: ./voice/${{ matrix.tag }}/Dockerfile

--- a/.github/workflows/wine.yml
+++ b/.github/workflows/wine.yml
@@ -29,7 +29,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_TOKEN }}
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v6
         with:
           context: ./wine
           file: ./wine/${{ matrix.tag }}/Dockerfile

--- a/bot/parkertron/Dockerfile
+++ b/bot/parkertron/Dockerfile
@@ -2,7 +2,7 @@ FROM    --platform=$TARGETOS/$TARGETARCH debian:bookworm
 
 LABEL   author="Michael Parker" maintainer="parker@pterodactyl.io"
 
-ENV     DEBIAN_FRONTEND noninteractive
+ENV     DEBIAN_FRONTEND=noninteractive
 
 RUN     apt update -y \
         # general packages

--- a/bot/sinusbot/Dockerfile
+++ b/bot/sinusbot/Dockerfile
@@ -3,7 +3,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH debian:bookworm-slim
 LABEL       org.opencontainers.image.authors="i2007@damw.eu"
 LABEL       version="1.0"
 
-ENV         DEBIAN_FRONTEND noninteractive
+ENV         DEBIAN_FRONTEND=noninteractive
 
 # Install Dependencies
 RUN         apt update \
@@ -14,8 +14,8 @@ RUN         apt update \
             && useradd -m -d /home/container container
 #RUN         python3 -m pip install requests
 
-ENV LANG C.UTF-8
-ENV LC_ALL C.UTF-8
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
 
 USER        container
 ENV         USER=container HOME=/home/container

--- a/box64/Dockerfile
+++ b/box64/Dockerfile
@@ -2,7 +2,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH debian:bookworm-slim
 
 LABEL       author="QuintenQVD" maintainer="josdekurk@gmail.com"
 
-ENV     DEBIAN_FRONTEND noninteractive
+ENV     DEBIAN_FRONTEND=noninteractive
 
 ## Update base packages
 RUN          apt update \

--- a/dotnet/2.1/Dockerfile
+++ b/dotnet/2.1/Dockerfile
@@ -2,7 +2,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH ghcr.io/parkervcp/yolks:debian
 
 LABEL       author="Torsten Widmann" maintainer="info@goover.de"
 
-ENV         DEBIAN_FRONTEND noninteractive
+ENV         DEBIAN_FRONTEND=noninteractive
 
 RUN         apt update -y \
             && apt upgrade -y \

--- a/dotnet/3.1/Dockerfile
+++ b/dotnet/3.1/Dockerfile
@@ -2,7 +2,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH ghcr.io/parkervcp/yolks:debian
 
 LABEL       author="Torsten Widmann" maintainer="info@goover.de"
 
-ENV         DEBIAN_FRONTEND noninteractive
+ENV         DEBIAN_FRONTEND=noninteractive
 
 RUN         apt update -y \
             && apt upgrade -y \

--- a/dotnet/5/Dockerfile
+++ b/dotnet/5/Dockerfile
@@ -2,7 +2,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH ghcr.io/parkervcp/yolks:debian
 
 LABEL       author="Torsten Widmann" maintainer="info@goover.de"
 
-ENV         DEBIAN_FRONTEND noninteractive
+ENV         DEBIAN_FRONTEND=noninteractive
 
 RUN         apt update -y \
             && apt upgrade -y \

--- a/dotnet/6/Dockerfile
+++ b/dotnet/6/Dockerfile
@@ -2,7 +2,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH ghcr.io/parkervcp/yolks:debian
 
 LABEL       author="Torsten Widmann" maintainer="info@goover.de"
 
-ENV         DEBIAN_FRONTEND noninteractive
+ENV         DEBIAN_FRONTEND=noninteractive
 
 RUN         apt update -y \
             && apt upgrade -y \

--- a/dotnet/7/Dockerfile
+++ b/dotnet/7/Dockerfile
@@ -2,7 +2,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH ghcr.io/parkervcp/yolks:debian
 
 LABEL       author="Torsten Widmann" maintainer="info@goover.de"
 
-ENV         DEBIAN_FRONTEND noninteractive
+ENV         DEBIAN_FRONTEND=noninteractive
 
 RUN         apt update -y \
             && apt upgrade -y \

--- a/dotnet/8/Dockerfile
+++ b/dotnet/8/Dockerfile
@@ -2,7 +2,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH ghcr.io/parkervcp/yolks:debian
 
 LABEL       author="Torsten Widmann" maintainer="info@goover.de"
 
-ENV         DEBIAN_FRONTEND noninteractive
+ENV         DEBIAN_FRONTEND=noninteractive
 
 RUN         apt update -y \
             && apt upgrade -y \

--- a/dotnet/9/Dockerfile
+++ b/dotnet/9/Dockerfile
@@ -2,7 +2,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH ghcr.io/parkervcp/yolks:debian
 
 LABEL       author="Torsten Widmann" maintainer="info@goover.de"
 
-ENV         DEBIAN_FRONTEND noninteractive
+ENV         DEBIAN_FRONTEND=noninteractive
 
 RUN         apt update -y \
             && apt upgrade -y \

--- a/games/altv/Dockerfile
+++ b/games/altv/Dockerfile
@@ -5,7 +5,7 @@ FROM    --platform=$TARGETOS/$TARGETARCH node:16-bookworm
 
 LABEL   author="goover" maintainer="info@goover.de"
 
-ENV     DEBIAN_FRONTEND noninteractive
+ENV     DEBIAN_FRONTEND=noninteractive
 
 RUN     useradd -m -d /home/container -s /bin/bash container
 

--- a/games/minetest/Dockerfile
+++ b/games/minetest/Dockerfile
@@ -1,5 +1,5 @@
 FROM 		--platform=$TARGETOS/$TARGETARCH ubuntu:22.04
-ENV         DEBIAN_FRONTEND noninteractive
+ENV         DEBIAN_FRONTEND=noninteractive
 
 RUN         apt update -y \
 			&& apt install -y curl ca-certificates openssl git tar gnupg2 sqlite3 fontconfig tzdata iproute2 libfreetype6 software-properties-common \

--- a/games/mta/Dockerfile
+++ b/games/mta/Dockerfile
@@ -1,6 +1,6 @@
 FROM  --platform=$TARGETOS/$TARGETARCH ubuntu:20.04
 
-ENV   DEBIAN_FRONTEND noninteractive
+ENV   DEBIAN_FRONTEND=noninteractive
 
 ## add container user
 RUN   useradd -m -d /home/container -s /bin/bash container

--- a/games/valheim/Dockerfile
+++ b/games/valheim/Dockerfile
@@ -2,7 +2,7 @@ FROM  --platform=$TARGETOS/$TARGETARCH ubuntu:22.04
 
 LABEL author="Daniel Barton" maintainer="danny6167@gmail.com"
 
-ENV   DEBIAN_FRONTEND noninteractive
+ENV   DEBIAN_FRONTEND=noninteractive
 
 ## add container user
 RUN   useradd -m -d /home/container -s /bin/bash container

--- a/mariadb/10.3/Dockerfile
+++ b/mariadb/10.3/Dockerfile
@@ -5,7 +5,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH mariadb:10.3
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
-ENV         DEBIAN_FRONTEND noninteractive
+ENV         DEBIAN_FRONTEND=noninteractive
 
 RUN         apt update -y \
             && apt install -y netcat \

--- a/mariadb/10.4/Dockerfile
+++ b/mariadb/10.4/Dockerfile
@@ -5,7 +5,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH mariadb:10.4
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
-ENV         DEBIAN_FRONTEND noninteractive
+ENV         DEBIAN_FRONTEND=noninteractive
 
 RUN         apt update -y \
             && apt install -y netcat \

--- a/mariadb/10.5/Dockerfile
+++ b/mariadb/10.5/Dockerfile
@@ -5,7 +5,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH mariadb:10.5
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
-ENV         DEBIAN_FRONTEND noninteractive
+ENV         DEBIAN_FRONTEND=noninteractive
 
 RUN         apt update -y \
             && apt install -y netcat \

--- a/mariadb/10.6/Dockerfile
+++ b/mariadb/10.6/Dockerfile
@@ -5,7 +5,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH mariadb:10.6
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
-ENV         DEBIAN_FRONTEND noninteractive
+ENV         DEBIAN_FRONTEND=noninteractive
 
 RUN         apt update -y \
             && apt install -y netcat \

--- a/mariadb/10.7/Dockerfile
+++ b/mariadb/10.7/Dockerfile
@@ -5,7 +5,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH mariadb:10.7
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
-ENV         DEBIAN_FRONTEND noninteractive
+ENV         DEBIAN_FRONTEND=noninteractive
 
 RUN         apt update -y \
             && apt install -y netcat \

--- a/mariadb/11.2/Dockerfile
+++ b/mariadb/11.2/Dockerfile
@@ -5,7 +5,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH mariadb:11.2
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
-ENV         DEBIAN_FRONTEND noninteractive
+ENV         DEBIAN_FRONTEND=noninteractive
 
 RUN         apt update -y \
             && apt install -y netcat \

--- a/mariadb/11.3/Dockerfile
+++ b/mariadb/11.3/Dockerfile
@@ -5,7 +5,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH mariadb:11.3
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
-ENV         DEBIAN_FRONTEND noninteractive
+ENV         DEBIAN_FRONTEND=noninteractive
 
 RUN         apt update -y \
             && apt install -y netcat \

--- a/mariadb/11.4/Dockerfile
+++ b/mariadb/11.4/Dockerfile
@@ -5,7 +5,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH mariadb:11.4
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
-ENV         DEBIAN_FRONTEND noninteractive
+ENV         DEBIAN_FRONTEND=noninteractive
 
 RUN         apt update -y \
             && apt install -y netcat-traditional \

--- a/mongodb/4/Dockerfile
+++ b/mongodb/4/Dockerfile
@@ -5,7 +5,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH mongo:4-focal
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
-ENV         DEBIAN_FRONTEND noninteractive
+ENV         DEBIAN_FRONTEND=noninteractive
 
 RUN         apt update -y \
             && apt install -y netcat iproute2 \

--- a/mongodb/5/Dockerfile
+++ b/mongodb/5/Dockerfile
@@ -5,7 +5,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH mongo:5-focal
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
-ENV         DEBIAN_FRONTEND noninteractive
+ENV         DEBIAN_FRONTEND=noninteractive
 
 RUN         apt update -y \
             && apt install -y netcat iproute2 \

--- a/mongodb/6/Dockerfile
+++ b/mongodb/6/Dockerfile
@@ -5,7 +5,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH mongo:6-jammy
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
-ENV         DEBIAN_FRONTEND noninteractive
+ENV         DEBIAN_FRONTEND=noninteractive
 
 RUN         apt update -y \
             && apt install -y netcat iproute2 \

--- a/mongodb/7/Dockerfile
+++ b/mongodb/7/Dockerfile
@@ -5,7 +5,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH mongo:7-jammy
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
-ENV         DEBIAN_FRONTEND noninteractive
+ENV         DEBIAN_FRONTEND=noninteractive
 
 RUN         apt update -y \
             && apt install -y netcat iproute2 \

--- a/oses/debian/Dockerfile
+++ b/oses/debian/Dockerfile
@@ -5,7 +5,7 @@ LABEL        author="Michael Parker" maintainer="parker@pterodactyl.io"
 LABEL        org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL        org.opencontainers.image.licenses=MIT
 
-ENV          DEBIAN_FRONTEND noninteractive
+ENV          DEBIAN_FRONTEND=noninteractive
 
 RUN          useradd -m -d /home/container -s /bin/bash container
 

--- a/postgres/10/Dockerfile
+++ b/postgres/10/Dockerfile
@@ -11,7 +11,7 @@ RUN adduser -D -h /home/container container
 RUN     apk add --no-cache tini curl iproute2 ca-certificates fontconfig git openssl sqlite tar tzdata
 
 USER container
-ENV HOME /home/container
+ENV HOME=/home/container
 WORKDIR /home/container
 
 STOPSIGNAL SIGINT

--- a/postgres/11/Dockerfile
+++ b/postgres/11/Dockerfile
@@ -11,7 +11,7 @@ RUN adduser -D -h /home/container container
 RUN     apk add --no-cache tini curl iproute2 ca-certificates fontconfig git openssl sqlite tar tzdata
 
 USER container
-ENV HOME /home/container
+ENV HOME=/home/container
 WORKDIR /home/container
 
 STOPSIGNAL SIGINT

--- a/postgres/12/Dockerfile
+++ b/postgres/12/Dockerfile
@@ -11,7 +11,7 @@ RUN adduser -D -h /home/container container
 RUN     apk add --no-cache tini curl iproute2 ca-certificates fontconfig git openssl sqlite tar tzdata
 
 USER container
-ENV HOME /home/container
+ENV HOME=/home/container
 WORKDIR /home/container
 
 STOPSIGNAL SIGINT

--- a/postgres/13/Dockerfile
+++ b/postgres/13/Dockerfile
@@ -11,7 +11,7 @@ RUN adduser -D -h /home/container container
 RUN     apk add --no-cache tini curl iproute2 ca-certificates fontconfig git openssl sqlite tar tzdata
 
 USER container
-ENV HOME /home/container
+ENV HOME=/home/container
 WORKDIR /home/container
 
 STOPSIGNAL SIGINT

--- a/postgres/14/Dockerfile
+++ b/postgres/14/Dockerfile
@@ -11,7 +11,7 @@ RUN adduser -D -h /home/container container
 RUN     apk add --no-cache tini curl iproute2 ca-certificates fontconfig git openssl sqlite tar tzdata fontconfig git openssl sqlite tar tzdata
 
 USER container
-ENV HOME /home/container
+ENV HOME=/home/container
 WORKDIR /home/container
 
 STOPSIGNAL SIGINT

--- a/postgres/16/Dockerfile
+++ b/postgres/16/Dockerfile
@@ -10,7 +10,7 @@ RUN adduser -D -h /home/container container
 
 RUN     apk add --no-cache tini curl iproute2 ca-certificates fontconfig git openssl sqlite tar tzdata
 USER container
-ENV HOME /home/container
+ENV HOME=/home/container
 WORKDIR /home/container
 
 STOPSIGNAL SIGINT

--- a/postgres/9/Dockerfile
+++ b/postgres/9/Dockerfile
@@ -10,7 +10,7 @@ RUN adduser -D -h /home/container container
 
 RUN     apk add --no-cache tini curl iproute2 ca-certificates fontconfig git openssl sqlite tar tzdata
 USER container
-ENV HOME /home/container
+ENV HOME=/home/container
 WORKDIR /home/container
 
 STOPSIGNAL SIGINT

--- a/redis/5/Dockerfile
+++ b/redis/5/Dockerfile
@@ -5,7 +5,7 @@ FROM    --platform=$TARGETOS/$TARGETARCH redis:5-bullseye
 
 LABEL   author="Michael Parker" maintainer="parker@pterodactyl.io"
 
-ENV     DEBIAN_FRONTEND noninteractive
+ENV     DEBIAN_FRONTEND=noninteractive
 
 RUN     apt -y update && \
         apt -y upgrade && \

--- a/redis/6/Dockerfile
+++ b/redis/6/Dockerfile
@@ -5,7 +5,7 @@ FROM    --platform=$TARGETOS/$TARGETARCH redis:6-bookworm
 
 LABEL   author="Michael Parker" maintainer="parker@pterodactyl.io"
 
-ENV     DEBIAN_FRONTEND noninteractive
+ENV     DEBIAN_FRONTEND=noninteractive
 
 RUN     apt -y update && \
         apt -y upgrade && \

--- a/redis/7/Dockerfile
+++ b/redis/7/Dockerfile
@@ -5,7 +5,7 @@ FROM    --platform=$TARGETOS/$TARGETARCH redis:7-bookworm
 
 LABEL   author="Michael Parker" maintainer="parker@pterodactyl.io"
 
-ENV     DEBIAN_FRONTEND noninteractive
+ENV     DEBIAN_FRONTEND=noninteractive
 
 RUN     apt -y update && \
         apt -y upgrade && \

--- a/steamcmd/dotnet/Dockerfile
+++ b/steamcmd/dotnet/Dockerfile
@@ -2,7 +2,7 @@ FROM    --platform=$TARGETOS/$TARGETARCH debian:bookworm-slim
 
 LABEL   author="Torsten Widmann" maintainer="info@goover.de"
 
-ENV     DEBIAN_FRONTEND noninteractive
+ENV     DEBIAN_FRONTEND=noninteractive
 
 RUN     dpkg --add-architecture i386 \
           && apt update \


### PR DESCRIPTION
## Description

- Change the ENV format to key=value as that is how docker wants it now
- Bump: docker/build-push-action to v6

### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?

<!-- The new image submission below can be removed if you are not adding a new image -->

