### PR TITLE
Steamcmd ubuntu24.04

### DIFF
--- a/steamcmd/ubuntu/Dockerfile
+++ b/steamcmd/ubuntu/Dockerfile
@@ -7,9 +7,51 @@ ENV         DEBIAN_FRONTEND=noninteractive
 
 RUN         dpkg --add-architecture i386 \
 			&& apt update \
-			&& apt upgrade -y \
-			&& apt -y install tar curl gcc g++ lib32gcc-s1 libgcc-10-dev libcurl4-gnutls-dev:i386 libssl-dev:i386 libssl-dev libcurl4t64:i386 lib32stdc++6 libcurl3t64-gnutls:i386 libsdl2-2.0-0:i386 iproute2 gdb libsdl1.2debian telnet net-tools netcat tzdata libtinfo6:i386 libcurl4-gnutls-dev:i386 libncurses6:i386 libcurl4-gnutls:i386 faketime:i386 \
-			&& apt -y install lib32tinfo6 lib32z1 libtbb12 libtinfo6 libstdc++6 readline-common libncursesw6 libfontconfig1 libnss-wrapper gettext-base libc6-i386 libcurl4t64 libssl3t64 libssl3t64:i386 libc6 libc6:i386 xvfb gdb libc++-dev tini 
+			&& apt upgrade -y 
+RUN			apt -y install \
+				tar \
+				curl \
+				gcc \
+				g++ \
+				lib32gcc-s1 \
+				libgcc-10-dev \
+				libcurl4-gnutls-dev:i386 \
+				libssl-dev:i386 \
+				libssl-dev \
+				libcurl4t64:i386 \
+				lib32stdc++6 \
+				libcurl3t64-gnutls:i386 \
+				libsdl2-2.0-0:i386 \
+				iproute2 gdb \
+				libsdl1.2debian \
+				telnet \
+				net-tools \
+				netcat tzdata \
+				libtinfo6:i386 \
+				libcurl4-gnutls-dev:i386 \
+				libncurses6:i386 \
+				libcurl4-gnutls:i386 \
+				faketime:i386 \
+				lib32tinfo6 \
+				lib32z1 \
+				libtbb12 \
+				libtinfo6 \
+				libstdc++6 \
+				readline-common \
+				libncursesw6 \
+				libfontconfig1 \
+				libnss-wrapper \
+				gettext-base \
+				libc6-i386 \
+				libcurl4t64 \
+				libssl3t64 \
+				libssl3t64:i386 \
+				libc6 \
+				libc6:i386 \
+				xvfb \
+				gdb \
+				libc++-dev \
+				tini 
 
 RUN 		useradd -d /home/container -m container
 

--- a/steamcmd/ubuntu/Dockerfile
+++ b/steamcmd/ubuntu/Dockerfile
@@ -8,8 +8,8 @@ ENV         DEBIAN_FRONTEND=noninteractive
 RUN         dpkg --add-architecture i386 \
 			&& apt update \
 			&& apt upgrade -y \
-			&& apt -y install tar curl gcc g++ lib32gcc-s1 libgcc-10-dev libcurl4-gnutls-dev:i386 libssl-dev:i386 libssl-dev libcurl4t64:i386 lib32tinfo6 libtinfo6:i386 lib32z1 lib32stdc++6 libncurses6:i386 libcurl3t64-gnutls:i386 libsdl2-2.0-0:i386 iproute2 gdb libsdl1.2debian libfontconfig1 telnet net-tools netcat tzdata libtinfo6:i386 libtinfo6:i386 libcurl4-gnutls-dev:i386 libcurl4:i386 libncurses6:i386 libcurl4-gnutls:i386 faketime:i386 \
-			&& apt -y install lib32tinfo6 lib32stdc++6 lib32z1 libtbb12 libtinfo6 libstdc++6 readline-common libncursesw6 libfontconfig1 libnss-wrapper gettext-base libc++-dev libc6-i386 libcurl4t64 libc6 libc6:i386 libssl3t64 libssl3t64:i386 libc6 libc6:i386 xvfb gdb libc++-dev tini 
+			&& apt -y install tar curl gcc g++ lib32gcc-s1 libgcc-10-dev libcurl4-gnutls-dev:i386 libssl-dev:i386 libssl-dev libcurl4t64:i386 lib32stdc++6 libcurl3t64-gnutls:i386 libsdl2-2.0-0:i386 iproute2 gdb libsdl1.2debian telnet net-tools netcat tzdata libtinfo6:i386 libcurl4-gnutls-dev:i386 libncurses6:i386 libcurl4-gnutls:i386 faketime:i386 \
+			&& apt -y install lib32tinfo6 lib32z1 libtbb12 libtinfo6 libstdc++6 readline-common libncursesw6 libfontconfig1 libnss-wrapper gettext-base libc6-i386 libcurl4t64 libssl3t64 libssl3t64:i386 libc6 libc6:i386 xvfb gdb libc++-dev tini 
 
 RUN 		useradd -d /home/container -m container
 

--- a/steamcmd/ubuntu/Dockerfile
+++ b/steamcmd/ubuntu/Dockerfile
@@ -1,17 +1,15 @@
-FROM        --platform=$TARGETOS/$TARGETARCH ubuntu:22.04
+FROM        --platform=$TARGETOS/$TARGETARCH ubuntu:24.04
 
-LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
-
-LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
-LABEL       org.opencontainers.image.licenses=MIT
+LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
+LABEL       org.opencontainers.image.licenses=AGPL-3.0-or-later
 
 ENV         DEBIAN_FRONTEND=noninteractive
 
 RUN         dpkg --add-architecture i386 \
 			&& apt update \
 			&& apt upgrade -y \
-			&& apt -y install tar curl gcc g++ lib32gcc-s1 libgcc1 libcurl4-gnutls-dev:i386 libssl-dev:i386 libssl-dev libcurl4:i386 lib32tinfo6 libtinfo6:i386 lib32z1 lib32stdc++6 libncurses5:i386 libcurl3-gnutls:i386 libsdl2-2.0-0:i386 iproute2 gdb libsdl1.2debian libfontconfig1 telnet net-tools netcat tzdata  libtinfo6:i386 libtbb2:i386 libtinfo5:i386 libcurl4-gnutls-dev:i386 libcurl4:i386 libncurses5:i386 libcurl3-gnutls:i386 faketime:i386 libtbb2:i386 \
-			&& apt -y install lib32tinfo6 lib32stdc++6 lib32z1 libtbb2 libtinfo5 libstdc++6 readline-common libncursesw5 libfontconfig1 libnss-wrapper gettext-base libc++-dev libc6-i386 libcurl4 libc6 libc6:i386 libssl3 libssl3:i386 libc6 libc6:i386 xvfb gdb libc++-dev tini 
+			&& apt -y install tar curl gcc g++ lib32gcc-s1 libgcc-10-dev libcurl4-gnutls-dev:i386 libssl-dev:i386 libssl-dev libcurl4t64:i386 lib32tinfo6 libtinfo6:i386 lib32z1 lib32stdc++6 libncurses6:i386 libcurl3t64-gnutls:i386 libsdl2-2.0-0:i386 iproute2 gdb libsdl1.2debian libfontconfig1 telnet net-tools netcat tzdata libtinfo6:i386 libtinfo6:i386 libcurl4-gnutls-dev:i386 libcurl4:i386 libncurses6:i386 libcurl4-gnutls:i386 faketime:i386 \
+			&& apt -y install lib32tinfo6 lib32stdc++6 lib32z1 libtbb12 libtinfo6 libstdc++6 readline-common libncursesw6 libfontconfig1 libnss-wrapper gettext-base libc++-dev libc6-i386 libcurl4t64 libc6 libc6:i386 libssl3t64 libssl3t64:i386 libc6 libc6:i386 xvfb gdb libc++-dev tini 
 
 RUN 		useradd -d /home/container -m container
 


### PR DESCRIPTION
## Description

- Bump our steamcmd Ubuntu image from 22.04 to 24.04 because we need a newer libc6 version. 
- All packages are replaced by there"direct" updated onces and I removed a bunch of duplicates

### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?

<!-- The new image submission below can be removed if you are not adding a new image -->

