### PR TITLE
Replace Pterodactyl branding with Pelican

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Yolks
 
-A curated collection of core images that can be used with Pterodactyl's Egg system. Each image is rebuilt
+A curated collection of core images that can be used with Pelican's Egg system. Each image is rebuilt
 periodically to ensure dependencies are always up-to-date.
 
 Images are hosted on `ghcr.io` and exist under the `games`, `installers`, and `yolks` spaces. The following logic
@@ -9,10 +9,10 @@ is used when determining which space an image will live under:
 * `games` — anything within the `games` folder in the repository. These are images built for running a specific game
 or type of game.
 * `installers` — anything living within the `installers` directory. These images are used by install scripts for different
-Eggs within Pterodactyl, not for actually running a game server. These images are only designed to reduce installation time
+Eggs within Pelican, not for actually running a game server. These images are only designed to reduce installation time
 and network usage by pre-installing common installation dependencies such as `curl` and `wget`.
 * `yolks` — these are more generic images that allow different types of games or scripts to run. They're generally just
-a specific version of software and allow different Eggs within Pterodactyl to switch out the underlying implementation. An
+a specific version of software and allow different Eggs within Pelican to switch out the underlying implementation. An
 example of this would be something like Java or Python which are used for running bots, Minecraft servers, etc.
 
 All of these images are available for `linux/amd64` and `linux/arm64` versions, unless otherwise specified, to use

--- a/apps/uptimekuma/Dockerfile
+++ b/apps/uptimekuma/Dockerfile
@@ -1,7 +1,7 @@
 FROM        --platform=$TARGETOS/$TARGETARCH node:22-alpine
 
 LABEL       author="Torsten Widmann" maintainer="info@goover.de"
-LABEL       org.opencontainers.image.source="https://github.com/gOOvER/own-pterodactyl-images"
+LABEL       org.opencontainers.image.source="https://github.com/gOOvER/own-pelican-images"
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN         apk update \

--- a/apps/uptimekuma/Dockerfile
+++ b/apps/uptimekuma/Dockerfile
@@ -1,7 +1,7 @@
 FROM        --platform=$TARGETOS/$TARGETARCH node:22-alpine
 
 LABEL       author="Torsten Widmann" maintainer="info@goover.de"
-LABEL       org.opencontainers.image.source="https://github.com/gOOvER/own-pelican-images"
+LABEL       org.opencontainers.image.source="https://github.com/gOOvER/own-pterodactyl-images"
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN         apk update \

--- a/bot/bastion/Dockerfile
+++ b/bot/bastion/Dockerfile
@@ -1,6 +1,6 @@
 FROM        --platform=$TARGETOS/$TARGETARCH mongo:7-jammy
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 ## install nodejs 20
 RUN apt update && apt install --no-install-recommends -y curl apt-transport-https ca-certificates gnupg \ 

--- a/bot/parkertron/Dockerfile
+++ b/bot/parkertron/Dockerfile
@@ -1,6 +1,6 @@
 FROM    --platform=$TARGETOS/$TARGETARCH debian:bookworm
 
-LABEL   author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL   author="Michael Parker" maintainer="parker@pelican.dev"
 
 ENV     DEBIAN_FRONTEND=noninteractive
 

--- a/bot/red/Dockerfile
+++ b/bot/red/Dockerfile
@@ -1,6 +1,6 @@
 FROM          --platform=$TARGETOS/$TARGETARCH python:3.11-slim-bookworm
 
-LABEL         author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL         author="Michael Parker" maintainer="parker@pelican.dev"
 
 
 RUN           mkdir -p /usr/share/man/man1

--- a/cassandra/java11_python3/Dockerfile
+++ b/cassandra/java11_python3/Dockerfile
@@ -2,7 +2,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH adoptopenjdk/openjdk11:alpine-jre
 
 LABEL       author="Pascal Zarrad" maintainer="p.zarrad@outlook.de"
 
-LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN         apk add --update --no-cache python3 py3-tz ca-certificates curl fontconfig git openssl sqlite tar tzdata \

--- a/cassandra/java8_python2/Dockerfile
+++ b/cassandra/java8_python2/Dockerfile
@@ -2,7 +2,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH adoptopenjdk/openjdk8:alpine-jre
 
 LABEL       author="Pascal Zarrad" maintainer="p.zarrad@outlook.de"
 
-LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN         apk add --update --no-cache python2 ca-certificates curl fontconfig git openssl sqlite tar tzdata \

--- a/erlang/22/Dockerfile
+++ b/erlang/22/Dockerfile
@@ -2,7 +2,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH erlang:22-alpine
 
 LABEL       author="Pascal Zarrad" maintainer="p.zarrad@outlook.de"
 
-LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN         apk add --update --no-cache ca-certificates curl git openssl sqlite tar tzdata iproute2 \

--- a/erlang/23/Dockerfile
+++ b/erlang/23/Dockerfile
@@ -2,7 +2,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH erlang:23-alpine
 
 LABEL       author="Pascal Zarrad" maintainer="p.zarrad@outlook.de"
 
-LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN         apk add --update --no-cache ca-certificates curl git openssl sqlite tar tzdata  iproute2\

--- a/erlang/24/Dockerfile
+++ b/erlang/24/Dockerfile
@@ -2,7 +2,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH erlang:24-alpine
 
 LABEL       author="Pascal Zarrad" maintainer="p.zarrad@outlook.de"
 
-LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN         apk add --update --no-cache ca-certificates curl git openssl sqlite tar tzdata iproute2 \

--- a/erlang/25/Dockerfile
+++ b/erlang/25/Dockerfile
@@ -2,7 +2,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH erlang:25-alpine
 
 LABEL       author="Pascal Zarrad" maintainer="p.zarrad@outlook.de"
 
-LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN         apk add --update --no-cache ca-certificates curl git openssl sqlite tar tzdata iproute2 \

--- a/erlang/26/Dockerfile
+++ b/erlang/26/Dockerfile
@@ -2,7 +2,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH erlang:26-alpine
 
 LABEL       author="Pascal Zarrad" maintainer="p.zarrad@outlook.de"
 
-LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN         apk add --update --no-cache ca-certificates curl git openssl sqlite tar tzdata iproute2 \

--- a/games/mohaa/Dockerfile
+++ b/games/mohaa/Dockerfile
@@ -2,7 +2,7 @@ FROM        ghcr.io/parkervcp/yolks:debian
 
 LABEL       author="Manuel Dielacher" maintainer="th3dilli@gmx.at"
 
-LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN			dpkg --add-architecture i386 \

--- a/games/source/Dockerfile
+++ b/games/source/Dockerfile
@@ -24,7 +24,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH debian:bookworm-slim
 
 LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
 
-LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
 ENV         DEBIAN_FRONTEND=noninteractive

--- a/games/source/Dockerfile
+++ b/games/source/Dockerfile
@@ -22,7 +22,7 @@
 
 FROM        --platform=$TARGETOS/$TARGETARCH debian:bookworm-slim
 
-LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
+LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
 
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT

--- a/games/source/Dockerfile
+++ b/games/source/Dockerfile
@@ -22,7 +22,7 @@
 
 FROM        --platform=$TARGETOS/$TARGETARCH debian:bookworm-slim
 
-LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
+LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
 
 LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT

--- a/games/thebattleforwesnoth/Dockerfile
+++ b/games/thebattleforwesnoth/Dockerfile
@@ -1,6 +1,6 @@
 FROM        --platform=$TARGETOS/$TARGETARCH debian:bookworm-slim
 
-LABEL author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL author="Michael Parker" maintainer="parker@pelican.dev"
 
 ## update base packages
 RUN apt update && apt upgrade -y

--- a/go/1.14/Dockerfile
+++ b/go/1.14/Dockerfile
@@ -22,7 +22,7 @@
 
 FROM        --platform=$TARGETOS/$TARGETARCH golang:1.14-alpine
 
-LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
+LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
 
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT

--- a/go/1.14/Dockerfile
+++ b/go/1.14/Dockerfile
@@ -22,7 +22,7 @@
 
 FROM        --platform=$TARGETOS/$TARGETARCH golang:1.14-alpine
 
-LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
+LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
 
 LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT

--- a/go/1.14/Dockerfile
+++ b/go/1.14/Dockerfile
@@ -24,7 +24,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH golang:1.14-alpine
 
 LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
 
-LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN         apk add --update --no-cache ca-certificates tzdata \

--- a/go/1.15/Dockerfile
+++ b/go/1.15/Dockerfile
@@ -24,7 +24,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH golang:1.15-alpine
 
 LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
 
-LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN         apk add --update --no-cache ca-certificates tzdata \

--- a/go/1.15/Dockerfile
+++ b/go/1.15/Dockerfile
@@ -22,7 +22,7 @@
 
 FROM        --platform=$TARGETOS/$TARGETARCH golang:1.15-alpine
 
-LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
+LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
 
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT

--- a/go/1.15/Dockerfile
+++ b/go/1.15/Dockerfile
@@ -22,7 +22,7 @@
 
 FROM        --platform=$TARGETOS/$TARGETARCH golang:1.15-alpine
 
-LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
+LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
 
 LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT

--- a/go/1.16/Dockerfile
+++ b/go/1.16/Dockerfile
@@ -22,7 +22,7 @@
 
 FROM        --platform=$TARGETOS/$TARGETARCH golang:1.16-alpine
 
-LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
+LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
 
 LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT

--- a/go/1.16/Dockerfile
+++ b/go/1.16/Dockerfile
@@ -22,7 +22,7 @@
 
 FROM        --platform=$TARGETOS/$TARGETARCH golang:1.16-alpine
 
-LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
+LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
 
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT

--- a/go/1.16/Dockerfile
+++ b/go/1.16/Dockerfile
@@ -24,7 +24,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH golang:1.16-alpine
 
 LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
 
-LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN         apk add --update --no-cache ca-certificates tzdata \

--- a/go/1.17/Dockerfile
+++ b/go/1.17/Dockerfile
@@ -22,7 +22,7 @@
 
 FROM        --platform=$TARGETOS/$TARGETARCH golang:1.17-alpine
 
-LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
+LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
 
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT

--- a/go/1.17/Dockerfile
+++ b/go/1.17/Dockerfile
@@ -24,7 +24,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH golang:1.17-alpine
 
 LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
 
-LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN         apk add --update --no-cache ca-certificates tzdata \

--- a/go/1.17/Dockerfile
+++ b/go/1.17/Dockerfile
@@ -22,7 +22,7 @@
 
 FROM        --platform=$TARGETOS/$TARGETARCH golang:1.17-alpine
 
-LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
+LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
 
 LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT

--- a/go/1.18/Dockerfile
+++ b/go/1.18/Dockerfile
@@ -22,7 +22,7 @@
 
 FROM        --platform=$TARGETOS/$TARGETARCH golang:1.18-alpine
 
-LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
+LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
 
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT

--- a/go/1.18/Dockerfile
+++ b/go/1.18/Dockerfile
@@ -24,7 +24,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH golang:1.18-alpine
 
 LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
 
-LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN         apk add --update --no-cache ca-certificates tzdata \

--- a/go/1.18/Dockerfile
+++ b/go/1.18/Dockerfile
@@ -22,7 +22,7 @@
 
 FROM        --platform=$TARGETOS/$TARGETARCH golang:1.18-alpine
 
-LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
+LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
 
 LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT

--- a/go/1.19/Dockerfile
+++ b/go/1.19/Dockerfile
@@ -22,7 +22,7 @@
 
 FROM        --platform=$TARGETOS/$TARGETARCH golang:1.19-alpine
 
-LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
+LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
 
 LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT

--- a/go/1.19/Dockerfile
+++ b/go/1.19/Dockerfile
@@ -22,7 +22,7 @@
 
 FROM        --platform=$TARGETOS/$TARGETARCH golang:1.19-alpine
 
-LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
+LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
 
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT

--- a/go/1.19/Dockerfile
+++ b/go/1.19/Dockerfile
@@ -24,7 +24,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH golang:1.19-alpine
 
 LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
 
-LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN         apk add --update --no-cache ca-certificates tzdata \

--- a/go/1.20/Dockerfile
+++ b/go/1.20/Dockerfile
@@ -24,7 +24,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH golang:1.20-alpine
 
 LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
 
-LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN         apk add --update --no-cache ca-certificates tzdata \

--- a/go/1.20/Dockerfile
+++ b/go/1.20/Dockerfile
@@ -22,7 +22,7 @@
 
 FROM        --platform=$TARGETOS/$TARGETARCH golang:1.20-alpine
 
-LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
+LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
 
 LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT

--- a/go/1.20/Dockerfile
+++ b/go/1.20/Dockerfile
@@ -22,7 +22,7 @@
 
 FROM        --platform=$TARGETOS/$TARGETARCH golang:1.20-alpine
 
-LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
+LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
 
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT

--- a/go/1.21/Dockerfile
+++ b/go/1.21/Dockerfile
@@ -22,7 +22,7 @@
 
 FROM        --platform=$TARGETOS/$TARGETARCH golang:1.21-alpine
 
-LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
+LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
 
 LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT

--- a/go/1.21/Dockerfile
+++ b/go/1.21/Dockerfile
@@ -22,7 +22,7 @@
 
 FROM        --platform=$TARGETOS/$TARGETARCH golang:1.21-alpine
 
-LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
+LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
 
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT

--- a/go/1.21/Dockerfile
+++ b/go/1.21/Dockerfile
@@ -24,7 +24,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH golang:1.21-alpine
 
 LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
 
-LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN         apk add --update --no-cache ca-certificates tzdata \

--- a/go/1.22/Dockerfile
+++ b/go/1.22/Dockerfile
@@ -22,7 +22,7 @@
 
 FROM        --platform=$TARGETOS/$TARGETARCH golang:1.22-alpine
 
-LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
+LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
 
 LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT

--- a/go/1.22/Dockerfile
+++ b/go/1.22/Dockerfile
@@ -24,7 +24,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH golang:1.22-alpine
 
 LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
 
-LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN         apk add --update --no-cache ca-certificates tzdata \

--- a/go/1.22/Dockerfile
+++ b/go/1.22/Dockerfile
@@ -22,7 +22,7 @@
 
 FROM        --platform=$TARGETOS/$TARGETARCH golang:1.22-alpine
 
-LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
+LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
 
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT

--- a/installers/alpine/Dockerfile
+++ b/installers/alpine/Dockerfile
@@ -22,7 +22,7 @@
 
 FROM        --platform=$TARGETOS/$TARGETARCH alpine:latest
 
-LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
+LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
 
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT

--- a/installers/alpine/Dockerfile
+++ b/installers/alpine/Dockerfile
@@ -22,7 +22,7 @@
 
 FROM        --platform=$TARGETOS/$TARGETARCH alpine:latest
 
-LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
+LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
 
 LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT

--- a/installers/alpine/Dockerfile
+++ b/installers/alpine/Dockerfile
@@ -24,7 +24,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH alpine:latest
 
 LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
 
-LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN         apk add --update --no-cache ca-certificates curl unzip tar git jq wget xz

--- a/installers/debian/Dockerfile
+++ b/installers/debian/Dockerfile
@@ -24,7 +24,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH debian:bookworm-slim
 
 LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
 
-LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
 ENV         DEBIAN_FRONTEND=noninteractive

--- a/installers/debian/Dockerfile
+++ b/installers/debian/Dockerfile
@@ -22,7 +22,7 @@
 
 FROM        --platform=$TARGETOS/$TARGETARCH debian:bookworm-slim
 
-LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
+LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
 
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT

--- a/installers/debian/Dockerfile
+++ b/installers/debian/Dockerfile
@@ -22,7 +22,7 @@
 
 FROM        --platform=$TARGETOS/$TARGETARCH debian:bookworm-slim
 
-LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
+LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
 
 LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT

--- a/java/11/Dockerfile
+++ b/java/11/Dockerfile
@@ -1,6 +1,6 @@
 FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:11-jdk-noble
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT

--- a/java/11/Dockerfile
+++ b/java/11/Dockerfile
@@ -2,7 +2,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:11-jdk-noble
 
 LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
-LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN         apt update -y \

--- a/java/11j9/Dockerfile
+++ b/java/11j9/Dockerfile
@@ -1,6 +1,6 @@
 FROM        --platform=$TARGETOS/$TARGETARCH ibm-semeru-runtimes:open-11-jdk
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 RUN         apt update -y \
             && apt install -y \

--- a/java/16/Dockerfile
+++ b/java/16/Dockerfile
@@ -2,7 +2,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:16-jdk-focal
 
 LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
-LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN         apt update -y \

--- a/java/16/Dockerfile
+++ b/java/16/Dockerfile
@@ -1,6 +1,6 @@
 FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:16-jdk-focal
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT

--- a/java/16j9/Dockerfile
+++ b/java/16j9/Dockerfile
@@ -1,6 +1,6 @@
 FROM        --platform=$TARGETOS/$TARGETARCH ibm-semeru-runtimes:open-16-jdk
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 RUN         apt update -y \
             && apt install -y \

--- a/java/17/Dockerfile
+++ b/java/17/Dockerfile
@@ -2,7 +2,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:17-jdk-noble
 
 LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
-LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN         apt update -y \

--- a/java/17/Dockerfile
+++ b/java/17/Dockerfile
@@ -1,6 +1,6 @@
 FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:17-jdk-noble
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT

--- a/java/19/Dockerfile
+++ b/java/19/Dockerfile
@@ -1,6 +1,6 @@
 FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:19-jdk-focal
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT

--- a/java/19/Dockerfile
+++ b/java/19/Dockerfile
@@ -2,7 +2,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:19-jdk-focal
 
 LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
-LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN         apt update -y \

--- a/java/21/Dockerfile
+++ b/java/21/Dockerfile
@@ -1,6 +1,6 @@
 FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:21-jdk-noble
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT

--- a/java/21/Dockerfile
+++ b/java/21/Dockerfile
@@ -2,7 +2,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:21-jdk-noble
 
 LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
-LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN         apt update -y \

--- a/java/22/Dockerfile
+++ b/java/22/Dockerfile
@@ -1,6 +1,6 @@
 FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:22-jdk-noble
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT

--- a/java/22/Dockerfile
+++ b/java/22/Dockerfile
@@ -2,7 +2,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:22-jdk-noble
 
 LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
-LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN         apt update -y \

--- a/java/25/Dockerfile
+++ b/java/25/Dockerfile
@@ -2,7 +2,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:25-jdk-noble
 
 LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
-LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN         apt update -y \

--- a/java/26/Dockerfile
+++ b/java/26/Dockerfile
@@ -2,7 +2,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:26-jdk-noble
 
 LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
-LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN         apt update -y \

--- a/java/8/Dockerfile
+++ b/java/8/Dockerfile
@@ -2,7 +2,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:8-jdk-noble
 
 LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
-LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN         apt update -y \

--- a/java/8/Dockerfile
+++ b/java/8/Dockerfile
@@ -1,6 +1,6 @@
 FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:8-jdk-noble
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT

--- a/java/8j9/Dockerfile
+++ b/java/8j9/Dockerfile
@@ -1,6 +1,6 @@
 FROM        --platform=$TARGETOS/$TARGETARCH ibm-semeru-runtimes:open-8-jdk
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 RUN         apt update -y \
             && apt install -y \

--- a/mariadb/10.3/Dockerfile
+++ b/mariadb/10.3/Dockerfile
@@ -1,9 +1,9 @@
 # -----------------------------------------------------
-# MariaDB Image for Pterodactyl
+# MariaDB Image for Pelican
 # -----------------------------------------------------
 FROM        --platform=$TARGETOS/$TARGETARCH mariadb:10.3
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 ENV         DEBIAN_FRONTEND=noninteractive
 

--- a/mariadb/10.4/Dockerfile
+++ b/mariadb/10.4/Dockerfile
@@ -1,9 +1,9 @@
 # -----------------------------------------------------
-# MariaDB Image for Pterodactyl
+# MariaDB Image for Pelican
 # -----------------------------------------------------
 FROM        --platform=$TARGETOS/$TARGETARCH mariadb:10.4
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 ENV         DEBIAN_FRONTEND=noninteractive
 

--- a/mariadb/10.5/Dockerfile
+++ b/mariadb/10.5/Dockerfile
@@ -1,9 +1,9 @@
 # -----------------------------------------------------
-# MariaDB Image for Pterodactyl
+# MariaDB Image for Pelican
 # -----------------------------------------------------
 FROM        --platform=$TARGETOS/$TARGETARCH mariadb:10.5
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 ENV         DEBIAN_FRONTEND=noninteractive
 

--- a/mariadb/10.6/Dockerfile
+++ b/mariadb/10.6/Dockerfile
@@ -1,9 +1,9 @@
 # -----------------------------------------------------
-# MariaDB Image for Pterodactyl
+# MariaDB Image for Pelican
 # -----------------------------------------------------
 FROM        --platform=$TARGETOS/$TARGETARCH mariadb:10.6
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 ENV         DEBIAN_FRONTEND=noninteractive
 

--- a/mariadb/10.7/Dockerfile
+++ b/mariadb/10.7/Dockerfile
@@ -1,9 +1,9 @@
 # -----------------------------------------------------
-# MariaDB Image for Pterodactyl
+# MariaDB Image for Pelican
 # -----------------------------------------------------
 FROM        --platform=$TARGETOS/$TARGETARCH mariadb:10.7
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 ENV         DEBIAN_FRONTEND=noninteractive
 

--- a/mariadb/11.2/Dockerfile
+++ b/mariadb/11.2/Dockerfile
@@ -1,9 +1,9 @@
 # -----------------------------------------------------
-# MariaDB Image for Pterodactyl
+# MariaDB Image for Pelican
 # -----------------------------------------------------
 FROM        --platform=$TARGETOS/$TARGETARCH mariadb:11.2
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 ENV         DEBIAN_FRONTEND=noninteractive
 

--- a/mariadb/11.3/Dockerfile
+++ b/mariadb/11.3/Dockerfile
@@ -1,9 +1,9 @@
 # -----------------------------------------------------
-# MariaDB Image for Pterodactyl
+# MariaDB Image for Pelican
 # -----------------------------------------------------
 FROM        --platform=$TARGETOS/$TARGETARCH mariadb:11.3
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 ENV         DEBIAN_FRONTEND=noninteractive
 

--- a/mariadb/11.4/Dockerfile
+++ b/mariadb/11.4/Dockerfile
@@ -1,9 +1,9 @@
 # -----------------------------------------------------
-# MariaDB Image for Pterodactyl
+# MariaDB Image for Pelican
 # -----------------------------------------------------
 FROM        --platform=$TARGETOS/$TARGETARCH mariadb:11.4
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 ENV         DEBIAN_FRONTEND=noninteractive
 

--- a/mariadb/11.5/Dockerfile
+++ b/mariadb/11.5/Dockerfile
@@ -1,9 +1,9 @@
 # -----------------------------------------------------
-# MariaDB Image for Pterodactyl
+# MariaDB Image for Pelican
 # -----------------------------------------------------
 FROM        --platform=$TARGETOS/$TARGETARCH mariadb:11.5
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 ENV         DEBIAN_FRONTEND=noninteractive
 

--- a/mariadb/11.6/Dockerfile
+++ b/mariadb/11.6/Dockerfile
@@ -1,9 +1,9 @@
 # -----------------------------------------------------
-# MariaDB Image for Pterodactyl
+# MariaDB Image for Pelican
 # -----------------------------------------------------
 FROM        --platform=$TARGETOS/$TARGETARCH mariadb:11.6
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 ENV         DEBIAN_FRONTEND=noninteractive
 

--- a/mongodb/5/Dockerfile
+++ b/mongodb/5/Dockerfile
@@ -3,7 +3,7 @@
 # ----------------------------------
 FROM        --platform=$TARGETOS/$TARGETARCH mongo:5-focal
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 ENV         DEBIAN_FRONTEND=noninteractive
 

--- a/mongodb/6/Dockerfile
+++ b/mongodb/6/Dockerfile
@@ -3,7 +3,7 @@
 # ----------------------------------
 FROM        --platform=$TARGETOS/$TARGETARCH mongo:6-jammy
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 ENV         DEBIAN_FRONTEND=noninteractive
 

--- a/mongodb/7/Dockerfile
+++ b/mongodb/7/Dockerfile
@@ -3,7 +3,7 @@
 # ----------------------------------
 FROM        --platform=$TARGETOS/$TARGETARCH mongo:7-jammy
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 ENV         DEBIAN_FRONTEND=noninteractive
 

--- a/mongodb/8/Dockerfile
+++ b/mongodb/8/Dockerfile
@@ -3,7 +3,7 @@
 # ----------------------------------
 FROM        --platform=$TARGETOS/$TARGETARCH mongo:8-noble
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 ENV         DEBIAN_FRONTEND=noninteractive
 

--- a/nodejs/12/Dockerfile
+++ b/nodejs/12/Dockerfile
@@ -1,6 +1,6 @@
 FROM        --platform=$TARGETOS/$TARGETARCH node:12-bullseye-slim
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 # add container user and set stop signal
 RUN         useradd -m -d /home/container container

--- a/nodejs/14/Dockerfile
+++ b/nodejs/14/Dockerfile
@@ -1,6 +1,6 @@
 FROM        --platform=$TARGETOS/$TARGETARCH node:14-bullseye-slim
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 # add container user and set stop signal
 RUN         useradd -m -d /home/container container

--- a/nodejs/16/Dockerfile
+++ b/nodejs/16/Dockerfile
@@ -1,6 +1,6 @@
 FROM        --platform=$TARGETOS/$TARGETARCH node:16-bookworm-slim
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 # add container user and set stop signal
 RUN         useradd -m -d /home/container container

--- a/nodejs/17/Dockerfile
+++ b/nodejs/17/Dockerfile
@@ -1,6 +1,6 @@
 FROM        --platform=$TARGETOS/$TARGETARCH node:17-bullseye-slim
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 # add container user and set stop signal
 RUN         useradd -m -d /home/container container

--- a/nodejs/18/Dockerfile
+++ b/nodejs/18/Dockerfile
@@ -1,6 +1,6 @@
 FROM        --platform=$TARGETOS/$TARGETARCH node:18-bookworm-slim
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 # add container user and set stop signal
 RUN         useradd -m -d /home/container container

--- a/nodejs/19/Dockerfile
+++ b/nodejs/19/Dockerfile
@@ -1,6 +1,6 @@
 FROM        --platform=$TARGETOS/$TARGETARCH node:19-bullseye-slim
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 # add container user and set stop signal
 RUN         useradd -m -d /home/container container

--- a/nodejs/20/Dockerfile
+++ b/nodejs/20/Dockerfile
@@ -1,6 +1,6 @@
 FROM        --platform=$TARGETOS/$TARGETARCH node:20-bookworm-slim
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 # add container user and set stop signal
 RUN         useradd -m -d /home/container container

--- a/nodejs/21/Dockerfile
+++ b/nodejs/21/Dockerfile
@@ -1,6 +1,6 @@
 FROM        --platform=$TARGETOS/$TARGETARCH node:21-bookworm-slim
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 # add container user and set stop signal
 RUN         useradd -m -d /home/container container

--- a/nodejs/22/Dockerfile
+++ b/nodejs/22/Dockerfile
@@ -1,6 +1,6 @@
 FROM        --platform=$TARGETOS/$TARGETARCH node:22-trixie-slim
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 # add container user and set stop signal
 RUN         useradd -m -d /home/container container

--- a/nodejs/23/Dockerfile
+++ b/nodejs/23/Dockerfile
@@ -1,6 +1,6 @@
 FROM        --platform=$TARGETOS/$TARGETARCH node:23-bookworm-slim
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 # add container user and set stop signal
 RUN         useradd -m -d /home/container container

--- a/nodejs/24/Dockerfile
+++ b/nodejs/24/Dockerfile
@@ -1,6 +1,6 @@
 FROM        --platform=$TARGETOS/$TARGETARCH node:24-trixie-slim
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 # add container user and set stop signal
 RUN         useradd -m -d /home/container container

--- a/nodejs/25/Dockerfile
+++ b/nodejs/25/Dockerfile
@@ -1,6 +1,6 @@
 FROM        --platform=$TARGETOS/$TARGETARCH node:25-trixie-slim
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 # add container user and set stop signal
 RUN         useradd -m -d /home/container container

--- a/nodejs/26/Dockerfile
+++ b/nodejs/26/Dockerfile
@@ -1,6 +1,6 @@
 FROM        --platform=$TARGETOS/$TARGETARCH node:26-trixie-slim
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 RUN         useradd -m -d /home/container container
 STOPSIGNAL SIGINT

--- a/oses/alpine/Dockerfile
+++ b/oses/alpine/Dockerfile
@@ -22,7 +22,7 @@
 
 FROM        --platform=$TARGETOS/$TARGETARCH alpine:latest
 
-LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
+LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
 
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT

--- a/oses/alpine/Dockerfile
+++ b/oses/alpine/Dockerfile
@@ -24,7 +24,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH alpine:latest
 
 LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
 
-LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN         apk add --update --no-cache ca-certificates tzdata tini \

--- a/oses/alpine/Dockerfile
+++ b/oses/alpine/Dockerfile
@@ -22,7 +22,7 @@
 
 FROM        --platform=$TARGETOS/$TARGETARCH alpine:latest
 
-LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
+LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
 
 LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT

--- a/oses/debian/Dockerfile
+++ b/oses/debian/Dockerfile
@@ -1,6 +1,6 @@
 FROM        --platform=$TARGETOS/$TARGETARCH debian:13-slim
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT

--- a/oses/debian/Dockerfile
+++ b/oses/debian/Dockerfile
@@ -2,7 +2,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH debian:13-slim
 
 LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
-LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
 ENV         DEBIAN_FRONTEND=noninteractive

--- a/oses/ubuntu/Dockerfile
+++ b/oses/ubuntu/Dockerfile
@@ -1,6 +1,6 @@
 FROM        --platform=$TARGETOS/$TARGETARCH ubuntu:24.04
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT

--- a/postgres/10/Dockerfile
+++ b/postgres/10/Dockerfile
@@ -3,9 +3,9 @@
 # ----------------------------------
 FROM --platform=$TARGETOS/$TARGETARCH postgres:10-alpine
 
-LABEL author="Parker" maintainer="parker@pterodactyl.io"
+LABEL author="Parker" maintainer="parker@pelican.dev"
 
-# UID 999 is the default pterodactyl user
+# UID 999 is the default pelican user
 RUN adduser -D -h /home/container container
 
 RUN     apk add --no-cache tini curl iproute2 ca-certificates fontconfig git openssl sqlite tar tzdata

--- a/postgres/11/Dockerfile
+++ b/postgres/11/Dockerfile
@@ -3,9 +3,9 @@
 # -----------------------------------
 FROM --platform=$TARGETOS/$TARGETARCH postgres:11-alpine
 
-LABEL author="Parker" maintainer="parker@pterodactyl.io"
+LABEL author="Parker" maintainer="parker@pelican.dev"
 
-# UID 999 is the default pterodactyl user
+# UID 999 is the default pelican user
 RUN adduser -D -h /home/container container
 
 RUN     apk add --no-cache tini curl iproute2 ca-certificates fontconfig git openssl sqlite tar tzdata

--- a/postgres/12/Dockerfile
+++ b/postgres/12/Dockerfile
@@ -3,9 +3,9 @@
 # ----------------------------------
 FROM --platform=$TARGETOS/$TARGETARCH postgres:12-alpine
 
-LABEL author="Parker" maintainer="parker@pterodactyl.io"
+LABEL author="Parker" maintainer="parker@pelican.dev"
 
-# UID 999 is the default pterodactyl user
+# UID 999 is the default pelican user
 RUN adduser -D -h /home/container container
 
 RUN     apk add --no-cache tini curl iproute2 ca-certificates fontconfig git openssl sqlite tar tzdata

--- a/postgres/13/Dockerfile
+++ b/postgres/13/Dockerfile
@@ -3,9 +3,9 @@
 # ----------------------------------
 FROM --platform=$TARGETOS/$TARGETARCH postgres:13-alpine
 
-LABEL author="Parker" maintainer="parker@pterodactyl.io"
+LABEL author="Parker" maintainer="parker@pelican.dev"
 
-# UID 999 is the default pterodactyl user
+# UID 999 is the default pelican user
 RUN adduser -D -h /home/container container
 
 RUN     apk add --no-cache tini curl iproute2 ca-certificates fontconfig git openssl sqlite tar tzdata

--- a/postgres/14/Dockerfile
+++ b/postgres/14/Dockerfile
@@ -3,9 +3,9 @@
 # ----------------------------------
 FROM --platform=$TARGETOS/$TARGETARCH postgres:14-alpine
 
-LABEL author="Parker" maintainer="parker@pterodactyl.io"
+LABEL author="Parker" maintainer="parker@pelican.dev"
 
-# UID 999 is the default pterodactyl user
+# UID 999 is the default pelican user
 RUN adduser -D -h /home/container container
 
 RUN     apk add --no-cache tini curl iproute2 ca-certificates fontconfig git openssl sqlite tar tzdata fontconfig git openssl sqlite tar tzdata

--- a/postgres/16/Dockerfile
+++ b/postgres/16/Dockerfile
@@ -3,9 +3,9 @@
 # ----------------------------------
 FROM --platform=$TARGETOS/$TARGETARCH postgres:16-alpine
 
-LABEL author="Parker" maintainer="parker@pterodactyl.io"
+LABEL author="Parker" maintainer="parker@pelican.dev"
 
-# UID 999 is the default pterodactyl user
+# UID 999 is the default pelican user
 RUN adduser -D -h /home/container container
 
 RUN     apk add --no-cache tini curl iproute2 ca-certificates fontconfig git openssl sqlite tar tzdata

--- a/postgres/17/Dockerfile
+++ b/postgres/17/Dockerfile
@@ -3,9 +3,9 @@
 # ----------------------------------
 FROM --platform=$TARGETOS/$TARGETARCH postgres:17-alpine
 
-LABEL author="Parker" maintainer="parker@pterodactyl.io"
+LABEL author="Parker" maintainer="parker@pelican.dev"
 
-# UID 999 is the default pterodactyl user
+# UID 999 is the default pelican user
 RUN adduser -D -h /home/container container
 
 RUN     apk add --no-cache tini curl iproute2 ca-certificates fontconfig git openssl sqlite tar tzdata

--- a/postgres/18/Dockerfile
+++ b/postgres/18/Dockerfile
@@ -3,9 +3,9 @@
 # ----------------------------------
 FROM --platform=$TARGETOS/$TARGETARCH postgres:18-alpine
 
-LABEL author="Parker" maintainer="parker@pterodactyl.io"
+LABEL author="Parker" maintainer="parker@pelican.dev"
 
-# UID 999 is the default pterodactyl user
+# UID 999 is the default pelican user
 RUN adduser -D -h /home/container container
 
 RUN     apk add --no-cache tini curl iproute2 ca-certificates fontconfig git openssl sqlite tar tzdata

--- a/postgres/9/Dockerfile
+++ b/postgres/9/Dockerfile
@@ -3,9 +3,9 @@
 # ----------------------------------
 FROM --platform=$TARGETOS/$TARGETARCH postgres:9-alpine
 
-LABEL author="Parker" maintainer="parker@pterodactyl.io"
+LABEL author="Parker" maintainer="parker@pelican.dev"
 
-# UID 999 is the default pterodactyl user
+# UID 999 is the default pelican user
 RUN adduser -D -h /home/container container
 
 RUN     apk add --no-cache tini curl iproute2 ca-certificates fontconfig git openssl sqlite tar tzdata

--- a/python/2.7/Dockerfile
+++ b/python/2.7/Dockerfile
@@ -1,6 +1,6 @@
 FROM        --platform=$TARGETOS/$TARGETARCH python:2.7-slim
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 RUN         apt update \
             && apt -y install git gcc g++ ca-certificates dnsutils curl iproute2 ffmpeg procps tini \

--- a/python/3.10/Dockerfile
+++ b/python/3.10/Dockerfile
@@ -1,6 +1,6 @@
 FROM        --platform=$TARGETOS/$TARGETARCH python:3.10-slim-bookworm
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 RUN         apt update \
             && apt -y install git gcc g++ ca-certificates dnsutils curl iproute2 ffmpeg procps tini \

--- a/python/3.11/Dockerfile
+++ b/python/3.11/Dockerfile
@@ -1,6 +1,6 @@
 FROM        --platform=$TARGETOS/$TARGETARCH  python:3.11-slim-bookworm
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 RUN         apt update \
             && apt -y install git gcc g++ ca-certificates dnsutils curl iproute2 ffmpeg procps tini \

--- a/python/3.12/Dockerfile
+++ b/python/3.12/Dockerfile
@@ -1,6 +1,6 @@
 FROM        --platform=$TARGETOS/$TARGETARCH python:3.12-slim-bookworm
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 RUN         apt update \
             && apt -y install git gcc g++ ca-certificates dnsutils curl iproute2 ffmpeg procps tini \

--- a/python/3.13/Dockerfile
+++ b/python/3.13/Dockerfile
@@ -1,6 +1,6 @@
 FROM        --platform=$TARGETOS/$TARGETARCH python:3.13-slim-bookworm
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 RUN         apt update \
             && apt -y install git gcc g++ ca-certificates dnsutils curl iproute2 ffmpeg procps tini \

--- a/python/3.14/Dockerfile
+++ b/python/3.14/Dockerfile
@@ -1,6 +1,6 @@
 FROM        --platform=$TARGETOS/$TARGETARCH python:3.14-slim-bookworm
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 RUN         apt update \
             && apt -y install git gcc g++ ca-certificates dnsutils curl iproute2 ffmpeg procps tini \

--- a/python/3.7/Dockerfile
+++ b/python/3.7/Dockerfile
@@ -1,6 +1,6 @@
 FROM        --platform=$TARGETOS/$TARGETARCH python:3.7-slim-bookworm
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 RUN         apt update \
             && apt -y install git gcc g++ ca-certificates dnsutils curl iproute2 ffmpeg procps tini \

--- a/python/3.8/Dockerfile
+++ b/python/3.8/Dockerfile
@@ -1,6 +1,6 @@
 FROM        --platform=$TARGETOS/$TARGETARCH python:3.8-slim-bookworm
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 RUN         apt update \
             && apt -y install git gcc g++ ca-certificates dnsutils curl iproute2 ffmpeg procps tini \

--- a/python/3.9/Dockerfile
+++ b/python/3.9/Dockerfile
@@ -1,6 +1,6 @@
 FROM        --platform=$TARGETOS/$TARGETARCH python:3.9-slim-bookworm
 
-LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL       author="Michael Parker" maintainer="parker@pelican.dev"
 
 RUN         apt update \
             && apt -y install git gcc g++ ca-certificates dnsutils curl iproute2 ffmpeg procps tini \

--- a/redis/5/Dockerfile
+++ b/redis/5/Dockerfile
@@ -3,7 +3,7 @@
 # ----------------------------------
 FROM    --platform=$TARGETOS/$TARGETARCH redis:5-bullseye
 
-LABEL   author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL   author="Michael Parker" maintainer="parker@pelican.dev"
 
 ENV     DEBIAN_FRONTEND=noninteractive
 

--- a/redis/6/Dockerfile
+++ b/redis/6/Dockerfile
@@ -3,7 +3,7 @@
 # ----------------------------------
 FROM    --platform=$TARGETOS/$TARGETARCH redis:6-bookworm
 
-LABEL   author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL   author="Michael Parker" maintainer="parker@pelican.dev"
 
 ENV     DEBIAN_FRONTEND=noninteractive
 

--- a/redis/7/Dockerfile
+++ b/redis/7/Dockerfile
@@ -3,7 +3,7 @@
 # ----------------------------------
 FROM    --platform=$TARGETOS/$TARGETARCH redis:7-bookworm
 
-LABEL   author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL   author="Michael Parker" maintainer="parker@pelican.dev"
 
 ENV     DEBIAN_FRONTEND=noninteractive
 

--- a/steamcmd/debian/Dockerfile
+++ b/steamcmd/debian/Dockerfile
@@ -2,7 +2,7 @@ FROM        --platform=$TARGETOS/$TARGETARCH debian:bookworm-slim
 
 LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
 
-LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
 ENV         DEBIAN_FRONTEND=noninteractive

--- a/steamcmd/debian/Dockerfile
+++ b/steamcmd/debian/Dockerfile
@@ -1,6 +1,6 @@
 FROM        --platform=$TARGETOS/$TARGETARCH debian:bookworm-slim
 
-LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
+LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
 
 LABEL       org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL       org.opencontainers.image.licenses=MIT

--- a/steamcmd/debian/Dockerfile
+++ b/steamcmd/debian/Dockerfile
@@ -1,6 +1,6 @@
 FROM        --platform=$TARGETOS/$TARGETARCH debian:bookworm-slim
 
-LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
+LABEL       author="Matthew Penner" maintainer="matthew@pelican.dev"
 
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT

--- a/steamcmd/sniper/Dockerfile
+++ b/steamcmd/sniper/Dockerfile
@@ -4,7 +4,7 @@
 FROM         --platform=$TARGETOS/$TARGETARCH registry.gitlab.steamos.cloud/steamrt/sniper/platform:latest-container-runtime-depot
 
 LABEL       author="Alexander Ballauf" maintainer="admin@ballaual.de"
-LABEL       org.opencontainers.image.description SteamRT3 Platform image for Pterodactyl Source engine servers. 
+LABEL       org.opencontainers.image.description SteamRT3 Platform image for Pelican Source engine servers. 
 
 # Install required packages
 RUN         dpkg --add-architecture i386 \

--- a/voice/teaspeak/Dockerfile
+++ b/voice/teaspeak/Dockerfile
@@ -24,7 +24,7 @@ FROM      --platform=$TARGETOS/$TARGETARCH debian:bookworm-slim
 
 LABEL     author="Torsten Widmann" maintainer="info@goover.de"
 
-LABEL     org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL     org.opencontainers.image.source="https://github.com/pelican-eggs/yolks"
 LABEL     org.opencontainers.image.licenses=MIT
 
 ENV       DEBIAN_FRONTEND=noninteractive

--- a/wine/10/Dockerfile
+++ b/wine/10/Dockerfile
@@ -3,7 +3,7 @@
 # ---------------------------------------
 FROM            ghcr.io/parkervcp/yolks:debian
 
-LABEL           author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL           author="Michael Parker" maintainer="parker@pelican.dev"
 LABEL           org.opencontainers.image.licenses=MIT
 
 # Install required packages

--- a/wine/11/Dockerfile
+++ b/wine/11/Dockerfile
@@ -3,7 +3,7 @@
 # ---------------------------------------
 FROM            ghcr.io/parkervcp/yolks:debian
 
-LABEL           author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL           author="Michael Parker" maintainer="parker@pelican.dev"
 LABEL           org.opencontainers.image.licenses=MIT
 
 # Install required packages

--- a/wine/7/Dockerfile
+++ b/wine/7/Dockerfile
@@ -3,7 +3,7 @@
 # ---------------------------------------
 FROM            ghcr.io/parkervcp/yolks:debian
 
-LABEL           author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL           author="Michael Parker" maintainer="parker@pelican.dev"
 LABEL           org.opencontainers.image.licenses=MIT
 
 # Install required packages

--- a/wine/8/Dockerfile
+++ b/wine/8/Dockerfile
@@ -3,7 +3,7 @@
 # ---------------------------------------
 FROM            ghcr.io/parkervcp/yolks:debian
 
-LABEL           author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL           author="Michael Parker" maintainer="parker@pelican.dev"
 LABEL           org.opencontainers.image.licenses=MIT
 
 # Install required packages

--- a/wine/9/Dockerfile
+++ b/wine/9/Dockerfile
@@ -3,7 +3,7 @@
 # ---------------------------------------
 FROM            ghcr.io/parkervcp/yolks:debian
 
-LABEL           author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL           author="Michael Parker" maintainer="parker@pelican.dev"
 LABEL           org.opencontainers.image.licenses=MIT
 
 # Install required packages

--- a/wine/devel/Dockerfile
+++ b/wine/devel/Dockerfile
@@ -3,7 +3,7 @@
 # ---------------------------------------
 FROM            ghcr.io/parkervcp/yolks:debian
 
-LABEL           author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL           author="Michael Parker" maintainer="parker@pelican.dev"
 LABEL           org.opencontainers.image.licenses=MIT
 
 # Install required packages

--- a/wine/latest/Dockerfile
+++ b/wine/latest/Dockerfile
@@ -3,7 +3,7 @@
 # ---------------------------------------
 FROM            ghcr.io/parkervcp/yolks:debian
 
-LABEL           author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL           author="Michael Parker" maintainer="parker@pelican.dev"
 LABEL           org.opencontainers.image.licenses=MIT
 
 # Install required packages

--- a/wine/staging/Dockerfile
+++ b/wine/staging/Dockerfile
@@ -3,7 +3,7 @@
 # ---------------------------------------
 FROM            ghcr.io/parkervcp/yolks:debian
 
-LABEL           author="Michael Parker" maintainer="parker@pterodactyl.io"
+LABEL           author="Michael Parker" maintainer="parker@pelican.dev"
 LABEL           org.opencontainers.image.licenses=MIT
 
 # Install required packages


### PR DESCRIPTION
Swaps out the remaining Pterodactyl references for Pelican, matching casing throughout (Pterodactyl -> Pelican, PTERO -> PELI). Doc links now point at pelican.dev. Where an old PTDL_v2 export sits next to an existing Pelican version, the old file keeps its name so nothing gets clobbered.